### PR TITLE
New virtual desk 2.0b base implementation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ check_env:
 $(PLUGIN_NAME).so: $(SOURCE_FILES) $(INCLUDE_FILES)
 	g++ -shared $(COMPILE_FLAGS) $(COMPILE_DEFINES) $(SOURCE_FILES) -o $(PLUGIN_NAME).so
 
+debug: $(SOURCE_FILES) $(INCLUDE_FILES)
+	g++ -DDEBUG -shared $(COMPILE_FLAGS) $(COMPILE_DEFINES) $(SOURCE_FILES) -o $(PLUGIN_NAME).so
+
 clean:
 	rm -f ./$(PLUGIN_NAME).so
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,20 @@ multiple screens, this plugin basically replicates that
 functionality.  
 Taking the previous example:
  - You will be on virtual desktop 1. Let's say you open your web browser on your first screen and an IDE on your second screen;
- - When you switch to virtual desktop 2, both screens will switch to empty workspaces. Let's say here you open your email client and your favourite chat applicaiton;
+ - When you switch to virtual desktop 2, both screens will switch to empty workspaces. Let's say here you open your email client and your favourite chat application;
  - If you switch back to virtual desktop 1, you will get back your web browser and the IDE on screen 1 and 2; and viceversa when you go back to virtual desktop 2.
+ 
+**WARNING**: the main branch is currently on `virtual-desktops` v. 2.0b, which is beta software. If you're experiencing any bug, please open an issue here and then consider switching to v. 1.0
 
 ## How does this work?
 
 ### It's just workspaces, really
-Internally, this simply ties _n_ workspaces to your _n_ screens, for each virtual desktop. That is, on virtual desktop 1 you will always have workspace 1 on screen 1 and workspace 2 on screen 2;
-on virtual desktop 2, you will always have workspace 3 on screen 1 and workspace 4 on screen 2, and so on.
+Internally, this simply ties _n_ workspaces to your _n_ screens, for each virtual desktop. That is, on virtual desktop 1 you will have workspace 1 on screen 1 and workspace 2 on screen 2;
+on virtual desktop 2, you will have workspace 3 on screen 1 and workspace 4 on screen 2, and so on.
 
-**Notice**: screen 1 and screen 2 are not necessarily what you expect your first and second screen to be, i.e., screen 1 is not necessarily your left screen, and screen 2 is not necessarily your right screen.
+However, if you focus another workspace on a given virtual desktop, the plugin will remember this and you will keep this layout (see [Layouts](#Layouts)). 
+
+**Notice**: screen 1 and screen 2 are not necessarily what you expect your first and second screen to be, e.g., screen 1 is not necessarily your left screen, and screen 2 is not necessarily your right screen.
 
 ### Hyprctl dispatchers
 
@@ -36,6 +40,10 @@ This plugin exposes a few hyprctl dispatchers:
 | printdesk (vdesk)| Prints to Hyprland log the specified vdesk or the currently active vdesk* (if no argument is given) | optional vdesk, see below | `printdesk` or `printdesk 2` or `printdesk coding`|
 | movetodesk vdesk(, window) | Moves the active/selected window to the specified `vdesk` | `vdesk`, optional window, see below | `movetodesk 2` or `movetodesk 2,title:kitty` |
 | movetodesksilent vdesk(, window) | same as `movetodesk`, but doesn't switch to desk | same as above | same as above |
+| vdeskreset (vdesk) | reset layouts on `vdesk` or on all vdesks if no argument is given (see [Layouts](#Layouts))  | optional vdesk, see below | `vdeskreset` or `vdeskreset 2` or `vdeskreset coding` |
+| nextdesk | go to next vdesk. Creates it if it doesn't exist | `none` | `nextdesk` |
+| cyclevdesks | cycle between currently existing vdesks. Goes back to vdesk 1 if next vdesk does not exist | `none` | `cyclevdesks` |
+| printlayout | print to Hyprland logs the current layout | `none` | `printlayout` |
 
 \*`printdesk` currently prints to the active Hyprland session log, thus probably not really useful. 
 
@@ -50,15 +58,11 @@ plugin will remember this association even if Hyprland kills the related workspa
 The `movetodesk` and `movetodesksilent` dispatchers work similarly to 
 Hyprland's `movetoworkspace` and `movetoworkspacesilent` dispatchers. See [Hyprland's wiki](https://wiki.hyprland.org/Configuring/Dispatchers/#list-of-dispatchers). Of course, make sure to use the `vdesk` syntax above instead of Hyprland's.
 
-#### Mix with Hyprland native workspaces, but know what you're doing 
-You can mix this with Hyprland native workspaces functionality, but beware
-of how this plugin manages workspaces. Every vdesk will _always_ operate on the _same_ set of workspaces. If you're on vdesk 1, with 2 monitors, and
-switch monitor 2 to workspace 4, switching to vdesk 2 will always show workspaces 3 and 4 (and switching back to vdesk 1 will show workspace 1 and 
-2).  
-Also notice that you can use `hyprctl dispatch vdesk n`, even if you have 
+#### Mix with Hyprland native workspaces 
+You can use `hyprctl dispatch vdesk n`, even if you have 
 no secondary screen connected at the moment (the behaviour would be identical to native workspaces). Also, I would REMOVE
 any workspace related configuration, such as `wsbind`. If you want to leverage [workspace-specific rules](https://wiki.hyprland.org/Configuring/Workspace-Rules/), you can: workspaces are always assigned 
-to the same vdesk given the same number of monitors. For instance:
+to the same vdesk given the same number of monitors, unless you focus (e.g. with hyprctl) another workspace (see [Layouts](#Layouts)). For instance:
  - Given two monitors:
    - vdesk 1 has workspaces 1 and 2;
    - vdesk 2 has workspaces 3 and 4, and so on;
@@ -74,14 +78,16 @@ The vdesk a workspace will end up to is easily computed by doing `ceil(workspace
 
 This plugin exposes a few configuration options, under the `plugin:virtual-desktops:` category, namely:
 
-| Name | type | example|
-|------|------|--------|
-| names | map[int:string], see below| `1:coding, 2:internet, 3:mail and chats`|
-| cycleworkspaces | `0` or `1`| `1`|
+| Name | description | type | example|
+|------|-------------|------|--------|
+| names | map a vdesk id with a name | map[int:string], see below| `names = 1:coding, 2:internet, 3:mail and chats`|
+| cycleworkspaces | if set to 1 and switching to the currently active vdesk, workspaces will be swapped between your monitors (see [swapactiveworkspaces](https://wiki.hyprland.org/Configuring/Dispatchers/#list-of-dispatchers))| `0` or `1`| `cycleworkspaces = 1`|
+| rememberlayout | chooses how layouts should be remembered (see [Layouts](#Layouts)), defaults to `size` | `none`, `size` or `monitors` | `remember = size` |
+| notifyinit | chooses whether to display the startup notification, defaults to 1 | `0` or `1` | `notifyinit = 0` |
+| verbose_logging | whether to log more stuff, defaults to 0 | `0` or `1` | `verbose_logging = 0` |
 
-* The `names` config option maps virtual desktop IDs to a name (you can then use this with the hyprctl [dispatcher](#hyprctl-dispatchers));
-* If `cycleworkspaces` is set to `1`, and you switch to the currently active virtual desktop, this swaps the workspaces of your two monitors (see hyprctl [swapactiveworkspaces](https://wiki.hyprland.org/Configuring/Dispatchers/#list-of-dispatchers)). 
-THIS CURRENTLY DOES NOT WORK WITH MORE THAN 2 MONITORS. If you need this feature, please feel welcome to submit a PR ^^ (see also the `dev` branch).
+* The `names` config option maps virtual desktop IDs to a name (you can then use this with the hyprctl [dispatchers](#hyprctl-dispatchers));
+* `cycleworkspaces`:  THIS CURRENTLY DOES NOT WORK WITH MORE THAN 2 MONITORS. If you need this feature, please feel welcome to submit a PR ^^.
 
 
 #### Example config 
@@ -90,9 +96,52 @@ plugin {
     virtual-desktops {
         names = 1:coding, 2:internet, 3:mail and chats 
         cycleworkspaces = 1
+        rememberlayout = size
+        notifyinit = 0
+        verbose_logging = 0
     }
 }
 ```
+
+## Layouts
+Version 2.0 of this plugin introduced the concept of a *layout*, with the meaning of "a specific combination of workspaces on a (more or less) specific combination of monitors".  
+In other words, `virtual-desktops` remembers if you focused another workspace on your vdesk, even if you switch to another vdesk and then come back to this one
+
+#### Example
+Say you have 2 monitors A and B, and you're on vdesk 1:
+ - On monitor A you have workspace 1, and on monitor B you have workspace 2;
+ - Now, say you focus workspace 4 with `hyprctl dispatch workspace 4` on monitor B. 
+ - If you switch to vdesk 2 and back to vdesk 1, you will see workspace 4 on monitor B instead of workspace 2.  
+  
+**Notice** that, in this case, workspace 4 would also be shown on vdesk 2.
+
+### Layouts are cached and restored if you disconnect/reconnect monitors
+Internally, every vdesk will cache all the previous layouts. Once a monitor is connected/disconnected, the plugin will try to look for a previously existing layout for this configuration
+and it will apply it.
+
+#### Example
+Continuing from the previous example, say you now disconnect monitor B and then you reconnect it, while being on vdesk 1:
+ - the previous layout will be matched and you will get back workspace 1 on monitor A and workspace 4 on monitor B.
+
+This would work also if instead of disconnecting and reconnecting monitor B, you connected a third monitor C and then disconnect it.
+
+
+### Choosing how to remember, or choosing to forget
+Version 2.0 also introduced the `rememberlayout` config option: with this option, we can choose if we want to match a layout by number of monitors (`size`) or by unique monitor descriptions (`monitors`). There is also the third and final option to not remember layouts at all (`none`).
+
+
+#### Example
+Continuing from the previous example. Say we now disconnect monitor B and connect monitor C: our connected monitors are A and C.
+
+ - if `rememberlayout = size` (the default), the existing layout will still be matched, we will have workspace 1 on monitor A, workspace 4 on monitor C;
+ - if `rememberlayout = monitors`, a new layout will be created with defaults: workspace 1 on monitor A, workspace 2 on monitor C;
+ - if `rememberlayout = none`, same as above.
+
+If we now disconnect monitor C and reconnect monitor B: our connected monitors are A and B.
+
+ - if `rememberlayout = size` (the default), the existing layout will be matched, we will have workspace 1 on monitor A, workspace 4 on monitor B;
+ - if `rememberlayout = monitors`, the existing layout will be matched, we will have workspace 1 on monitor A, workspace 4 on monitor B;
+ - if `rememberlayout = none`, a new layout will be created with defaults: workspace 1 on monitor A, workspace 2 on monitor C.
 
 
 ## Install

--- a/hyprload.toml
+++ b/hyprload.toml
@@ -1,6 +1,6 @@
 [virtual-desktops]
 description = "Virtual desktops"
-version = "1.0.0"
+version = "2.0b"
 author = "LevMyskin"
 
 [virtual-desktops.build]

--- a/include/VirtualDesk.hpp
+++ b/include/VirtualDesk.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#define VDESK_H
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <src/helpers/Monitor.hpp>
+#include "globals.hpp"
+#include "utils.hpp"
+
+typedef std::unordered_map<int, int>         WorkspaceMap;
+typedef std::unordered_map<std::string, int> Layout;
+typedef std::string                          MonitorName;
+
+/* 
+* Each virtual desk holds a list of layouts. Layouts remember which workspace was on which monitor 
+* when those exact monitors (or that exact number of monitors) is/was connected.
+* VirtualDeskManager holds instead a map of vdesk_id -> virtual desk.
+*/
+
+class VirtualDesk {
+  public:
+    VirtualDesk(int id = 1, std::string name = "1");
+    int                             id;
+    std::string                     name;
+    std::vector<Layout>             layouts;
+
+    const Layout&                   activeLayout(const RememberLayoutConf&);
+    Layout&                         searchActiveLayout(const RememberLayoutConf&);
+    std::unordered_set<std::string> setFromMonitors(const std::vector<std::shared_ptr<CMonitor>>&);
+    void                            changeWorkspaceOnMonitor(int, CMonitor*);
+    void                            invalidateActiveLayout();
+    void                            resetLayout();
+    void                            deleteInvalidMonitor(CMonitor*);
+    void                            deleteInvalidMonitorOnAllLayouts(CMonitor*);
+
+  private:
+    int                                    m_activeLayout_idx;
+    bool                                   activeIsValid = false;
+    Layout                                 generateCurrentMonitorLayout();
+    std::vector<std::shared_ptr<CMonitor>> currentlyEnabledMonitors();
+    static std::string                     monitorDesc(const CMonitor&);
+    void                                   checkAndAdaptLayout(Layout*);
+};

--- a/include/VirtualDeskManager.hpp
+++ b/include/VirtualDeskManager.hpp
@@ -1,0 +1,33 @@
+
+#pragma once
+
+#define VDESK_MANAGER_H
+
+#include "VirtualDesk.hpp"
+
+class VirtualDeskManager {
+
+  public:
+    VirtualDeskManager();
+    std::unordered_map<int, std::shared_ptr<VirtualDesk>> vdesksMap;
+    int                                                   prevDesk      = -1;
+    std::unordered_map<int, std::string>                  vdeskNamesMap = {{1, "1"}};
+    RememberLayoutConf                                    conf;
+    const std::shared_ptr<VirtualDesk>&                   activeVdesk();
+    void                                                  changeActiveDesk(std::string&, bool);
+    void                                                  changeActiveDesk(int, bool);
+    void                                                  previousDesk();
+    void                                                  applyCurrentVDesk();
+    int                                                   moveToDesk(std::string&);
+    void                                                  loadLayoutConf();
+    void                                                  invalidateAllLayouts();
+    void                                                  resetAllVdesks();
+    void                                                  deleteInvalidMonitorsOnAllVdesks(CMonitor*);
+
+  private:
+    int       m_activeDeskKey = 1;
+    bool      confLoaded      = false;
+    void      cycleWorkspaces();
+    int       getOrCreateDeskIdFromName(const std::string& name);
+    CMonitor* getCurrentMonitor();
+};

--- a/include/VirtualDeskManager.hpp
+++ b/include/VirtualDeskManager.hpp
@@ -17,17 +17,19 @@ class VirtualDeskManager {
     void                                                  changeActiveDesk(std::string&, bool);
     void                                                  changeActiveDesk(int, bool);
     void                                                  previousDesk();
+    void                                                  nextDesk(bool cycle);
     void                                                  applyCurrentVDesk();
     int                                                   moveToDesk(std::string&);
     void                                                  loadLayoutConf();
     void                                                  invalidateAllLayouts();
     void                                                  resetAllVdesks();
+    void                                                  resetVdesk(const std::string& arg);
     void                                                  deleteInvalidMonitorsOnAllVdesks(CMonitor*);
 
   private:
     int       m_activeDeskKey = 1;
     bool      confLoaded      = false;
     void      cycleWorkspaces();
-    int       getOrCreateDeskIdFromName(const std::string& name);
+    int       getDeskIdFromName(const std::string& name, bool createIfNotFound = true);
     CMonitor* getCurrentMonitor();
 };

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -17,8 +17,10 @@ const std::string MOVETODESK_DISPATCH_STR       = "movetodesk";
 const std::string MOVETODESKSILENT_DISPATCH_STR = "movetodesksilent";
 const std::string RESET_VDESK_DISPATCH_STR      = "vdeskreset";
 const std::string PREVDESK_DISPATCH_STR         = "prevdesk";
+const std::string NEXTDESK_DISPATCH_STR         = "nextdesk";
 const std::string PRINTDESK_DISPATCH_STR        = "printdesk";
 const std::string PRINTLAYOUT_DISPATCH_STR      = "printlayout";
+const std::string CYCLEVDESK_DISPATCH_STR       = "cyclevdesks";
 
 enum RememberLayoutConf {
     none     = 0,
@@ -27,7 +29,7 @@ enum RememberLayoutConf {
 };
 
 RememberLayoutConf layoutConfFromInt(const int64_t);
-void               printLog(std::string s);
+void               printLog(std::string s, LogLevel level = INFO);
 
 std::string        parseMoveDispatch(std::string& arg);
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -22,13 +22,18 @@ const std::string PRINTDESK_DISPATCH_STR        = "printdesk";
 const std::string PRINTLAYOUT_DISPATCH_STR      = "printlayout";
 const std::string CYCLEVDESK_DISPATCH_STR       = "cyclevdesks";
 
+const std::string REMEMBER_NONE     = "none";
+const std::string REMEMBER_SIZE     = "size";
+const std::string REMEMBER_MONITORS = "monitors";
+
 enum RememberLayoutConf {
     none     = 0,
-    layout   = 1,
+    size     = 1,
     monitors = 2
 };
 
 RememberLayoutConf layoutConfFromInt(const int64_t);
+RememberLayoutConf layoutConfFromString(const std::string& conf);
 void               printLog(std::string s, LogLevel level = INFO);
 
 std::string        parseMoveDispatch(std::string& arg);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#define UTILS_H
+
+#include "src/debug/Log.hpp"
+#include "globals.hpp"
+#include "src/config/ConfigManager.hpp"
+#include <string>
+
+const std::string VIRTUALDESK_NAMES_CONF        = "plugin:virtual-desktops:names";
+const std::string CYCLEWORKSPACES_CONF          = "plugin:virtual-desktops:cycleworkspaces";
+const std::string REMEMBER_LAYOUT_CONF          = "plugin:virtual-desktops:rememberlayout";
+const std::string NOTIFY_INIT                   = "plugin:virtual-desktops:notifyinit";
+const std::string VERBOSE_LOGS                  = "plugin:virtual-desktops:verbose_logging";
+const std::string VDESK_DISPATCH_STR            = "vdesk";
+const std::string MOVETODESK_DISPATCH_STR       = "movetodesk";
+const std::string MOVETODESKSILENT_DISPATCH_STR = "movetodesksilent";
+const std::string RESET_VDESK_DISPATCH_STR      = "vdeskreset";
+const std::string PREVDESK_DISPATCH_STR         = "prevdesk";
+const std::string PRINTDESK_DISPATCH_STR        = "printdesk";
+const std::string PRINTLAYOUT_DISPATCH_STR      = "printlayout";
+
+enum RememberLayoutConf {
+    none     = 0,
+    layout   = 1,
+    monitors = 2
+};
+
+RememberLayoutConf layoutConfFromInt(const int64_t);
+void               printLog(std::string s);
+
+std::string        parseMoveDispatch(std::string& arg);
+
+bool               isVerbose();

--- a/src/VirtualDesk.cpp
+++ b/src/VirtualDesk.cpp
@@ -44,7 +44,7 @@ Layout& VirtualDesk::searchActiveLayout(const RememberLayoutConf& conf) {
             }
             break;
         }
-        case RememberLayoutConf::layout: {
+        case RememberLayoutConf::size: {
             int idx = 0;
             for (auto& layout : layouts) {
                 if (layout.size() == monitors.size()) {
@@ -60,7 +60,7 @@ Layout& VirtualDesk::searchActiveLayout(const RememberLayoutConf& conf) {
             }
             break;
         }
-        case RememberLayoutConf::none: break;
+        case RememberLayoutConf::none: layouts.clear();
     }
     layouts.push_back(generateCurrentMonitorLayout());
     m_activeLayout_idx = layouts.size() - 1;

--- a/src/VirtualDesk.cpp
+++ b/src/VirtualDesk.cpp
@@ -1,0 +1,159 @@
+#include "VirtualDesk.hpp"
+#include <src/Compositor.hpp>
+#include <numeric>
+#include <algorithm>
+
+VirtualDesk::VirtualDesk(int id, std::string name) {
+    this->id   = id;
+    this->name = name;
+    layouts.push_back(generateCurrentMonitorLayout());
+    m_activeLayout_idx = 0;
+}
+
+const Layout& VirtualDesk::activeLayout(const RememberLayoutConf& conf) {
+    if (!activeIsValid) {
+        activeIsValid = true;
+        searchActiveLayout(conf);
+    }
+    return layouts[m_activeLayout_idx];
+}
+
+Layout& VirtualDesk::searchActiveLayout(const RememberLayoutConf& conf) {
+
+    auto monitors = currentlyEnabledMonitors();
+    switch (conf) {
+        case RememberLayoutConf::monitors: {
+            // Compute hash set of descriptions
+            auto currentSet = setFromMonitors(monitors);
+            int  idx        = 0;
+            for (auto& layout : layouts) {
+                std::unordered_set<std::string> set;
+                for (const auto& [k, v] : layout) {
+                    set.insert(k);
+                }
+
+                std::unordered_set<std::string> intersection;
+                std::set_intersection(set.begin(), set.end(), currentSet.begin(), currentSet.end(), std::inserter(intersection, intersection.begin()));
+                if (intersection.size() == set.size()) {
+                    if (isVerbose())
+                        printLog("Found layout with monitors");
+                    m_activeLayout_idx = idx;
+                    return layouts[m_activeLayout_idx];
+                }
+                idx++;
+            }
+            break;
+        }
+        case RememberLayoutConf::layout: {
+            int idx = 0;
+            for (auto& layout : layouts) {
+                if (layout.size() == monitors.size()) {
+                    if (isVerbose())
+                        printLog("Found layout with size " + std::to_string(layout.size()));
+                    // check layout is valid and substitute invalid monitors
+                    checkAndAdaptLayout(&layout);
+
+                    m_activeLayout_idx = idx;
+                    return layouts[idx];
+                }
+                idx++;
+            }
+            break;
+        }
+        case RememberLayoutConf::none: break;
+    }
+    layouts.push_back(generateCurrentMonitorLayout());
+    m_activeLayout_idx = layouts.size() - 1;
+    return layouts[m_activeLayout_idx];
+}
+
+void VirtualDesk::changeWorkspaceOnMonitor(int workspaceId, CMonitor* monitor) {
+    layouts[m_activeLayout_idx][monitorDesc(*monitor)] = workspaceId;
+}
+
+void VirtualDesk::invalidateActiveLayout() {
+    activeIsValid = false;
+}
+
+void VirtualDesk::resetLayout() {
+    layouts[m_activeLayout_idx] = generateCurrentMonitorLayout();
+}
+
+void VirtualDesk::deleteInvalidMonitorOnAllLayouts(CMonitor* monitor) {
+    for (auto layout : layouts) {
+        deleteInvalidMonitor(monitor);
+    }
+}
+
+void VirtualDesk::deleteInvalidMonitor(CMonitor* monitor) {
+    Layout layout_copy(layouts[m_activeLayout_idx]);
+    for (auto const& [desc, workspaceId] : layout_copy) {
+        if (monitorDesc(*monitor) == desc) {
+            int                       n = INT_MAX;
+            std::shared_ptr<CMonitor> newMonitor;
+
+            // Just place it on the less busy monitor
+            for (auto mon : currentlyEnabledMonitors()) {
+                if (mon->ID == monitor->ID)
+                    continue;
+                auto n_on_mon = g_pCompositor->getWindowsOnWorkspace(mon->activeWorkspace);
+                if (n_on_mon < n) {
+                    n          = n_on_mon;
+                    newMonitor = mon;
+                }
+            }
+            layouts[m_activeLayout_idx][monitorDesc(*newMonitor)] = workspaceId;
+            layouts[m_activeLayout_idx].erase(desc);
+        }
+    }
+}
+
+void VirtualDesk::checkAndAdaptLayout(Layout* layout) {
+    for (auto [desc, wid] : Layout(*layout)) {
+        auto fromDesc = g_pCompositor->getMonitorFromDesc(desc);
+        if (!fromDesc || !fromDesc->m_bEnabled) {
+            // Let's try to find a "new" monitor which wasn't in
+            // the layout before. If we don't find it, not much we can
+            // do except for removing this monitor
+            for (const auto& mon : currentlyEnabledMonitors()) {
+                if (!layout->contains(monitorDesc(*mon))) {
+                    (*layout)[monitorDesc(*mon)] = wid;
+                    (*layout).erase(desc);
+                    return;
+                }
+            }
+            (*layout).erase(desc);
+        }
+    }
+}
+
+std::unordered_set<std::string> VirtualDesk::setFromMonitors(const std::vector<std::shared_ptr<CMonitor>>& monitors) {
+    std::unordered_set<std::string> set;
+    std::transform(monitors.begin(), monitors.end(), std::inserter(set, set.begin()), [](auto mon) { return monitorDesc(*mon); });
+    return set;
+}
+
+Layout VirtualDesk::generateCurrentMonitorLayout() {
+    Layout layout;
+
+    auto   monitors = currentlyEnabledMonitors();
+    if (PHANDLE && isVerbose())
+        printLog("vdesk " + name + " computing new layout for " + std::to_string(monitors.size()) + " monitors");
+    auto vdeskFirstWorkspace = (this->id - 1) * monitors.size() + 1;
+    int  j                   = 0;
+    for (int i = vdeskFirstWorkspace; i < vdeskFirstWorkspace + monitors.size(); i++) {
+        layout[monitorDesc(*monitors[j])] = i;
+        j++;
+    }
+    return layout;
+}
+
+std::vector<std::shared_ptr<CMonitor>> VirtualDesk::currentlyEnabledMonitors() {
+    std::vector<std::shared_ptr<CMonitor>> monitors;
+    std::copy_if(g_pCompositor->m_vMonitors.begin(), g_pCompositor->m_vMonitors.end(), std::back_inserter(monitors), [](auto mon) { return mon->m_bEnabled; });
+    return monitors;
+}
+
+std::string VirtualDesk::monitorDesc(const CMonitor& monitor) {
+    return monitor.output->description ? monitor.output->description : "";
+}

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -2,7 +2,7 @@
 #include <src/Compositor.hpp>
 
 VirtualDeskManager::VirtualDeskManager() {
-    this->conf       = RememberLayoutConf::layout;
+    this->conf       = RememberLayoutConf::size;
     vdeskNamesMap[1] = "1";
     vdesksMap[1]     = std::make_shared<VirtualDesk>();
 }
@@ -158,8 +158,8 @@ void VirtualDeskManager::loadLayoutConf() {
     // Maybe in a future release :)
     if (confLoaded)
         return;
-    static auto* const PREMEMBER_LAYOUT = &HyprlandAPI::getConfigValue(PHANDLE, REMEMBER_LAYOUT_CONF)->intValue;
-    conf                                = layoutConfFromInt(*PREMEMBER_LAYOUT);
+    static auto* const PREMEMBER_LAYOUT = &HyprlandAPI::getConfigValue(PHANDLE, REMEMBER_LAYOUT_CONF)->strValue;
+    conf                                = layoutConfFromString(*PREMEMBER_LAYOUT);
     confLoaded                          = true;
 }
 

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -1,0 +1,215 @@
+#include "VirtualDeskManager.hpp"
+#include <src/Compositor.hpp>
+
+VirtualDeskManager::VirtualDeskManager() {
+    this->conf       = RememberLayoutConf::layout;
+    vdeskNamesMap[1] = "1";
+    vdesksMap[1]     = std::make_shared<VirtualDesk>();
+}
+
+const std::shared_ptr<VirtualDesk>& VirtualDeskManager::activeVdesk() {
+    return vdesksMap[m_activeDeskKey];
+}
+
+void VirtualDeskManager::changeActiveDesk(std::string& arg, bool apply) {
+    int vdeskId;
+    try {
+        vdeskId = std::stoi(arg);
+    } catch (std::exception const& ex) { vdeskId = getOrCreateDeskIdFromName(arg); }
+
+    changeActiveDesk(vdeskId, apply);
+}
+
+void VirtualDeskManager::changeActiveDesk(int vdeskId, bool apply) {
+    if (vdeskId == activeVdesk()->id) {
+        cycleWorkspaces();
+        return;
+    }
+
+    if (!vdesksMap.contains(vdeskId)) {
+        if (isVerbose())
+            printLog("creating new vdesk with id " + std::to_string(vdeskId));
+        if (!vdeskNamesMap.contains(vdeskId))
+            vdeskNamesMap[vdeskId] = std::to_string(vdeskId);
+        vdesksMap[vdeskId] = std::make_shared<VirtualDesk>(vdeskId, vdeskNamesMap[vdeskId]);
+    }
+    prevDesk        = activeVdesk()->id;
+    m_activeDeskKey = vdeskId;
+    if (apply)
+        applyCurrentVDesk();
+}
+
+void VirtualDeskManager::previousDesk() {
+    if (prevDesk == -1) {
+        printLog("There's no previous desk");
+        return;
+    }
+    changeActiveDesk(prevDesk, true);
+}
+
+void VirtualDeskManager::applyCurrentVDesk() {
+    if (isVerbose())
+        printLog("applying vdesk" + activeVdesk()->name);
+    auto currentMonitor = getCurrentMonitor();
+    if (!currentMonitor) {
+        printLog("There are no monitors!");
+        return;
+    }
+    auto        layout = activeVdesk()->activeLayout(conf);
+    CWorkspace* focusedWorkspace;
+    for (auto const& [monitorDesc, workspaceId] : layout) {
+        CMonitor* mon = g_pCompositor->getMonitorFromDesc(monitorDesc);
+        if (!mon) {
+            printLog("There is no monitor with description " + monitorDesc);
+            continue;
+        }
+        CWorkspace* workspace = g_pCompositor->getWorkspaceByID(workspaceId);
+        if (!workspace) {
+            printLog("Creating workspace " + std::to_string(workspaceId));
+            workspace = g_pCompositor->createNewWorkspace(workspaceId, mon->ID);
+        }
+
+        if (workspace->m_iMonitorID != mon->ID)
+            g_pCompositor->moveWorkspaceToMonitor(workspace, currentMonitor);
+
+        // Hack: we change the workspace on the current monitor as our last operation,
+        // so that we also automatically focus it
+        if (currentMonitor && mon->ID == currentMonitor->ID) {
+            focusedWorkspace = workspace;
+            continue;
+        }
+        mon->changeWorkspace(workspace, false);
+    }
+    if (currentMonitor)
+        currentMonitor->changeWorkspace(focusedWorkspace, false);
+}
+
+int VirtualDeskManager::moveToDesk(std::string& arg) {
+    // TODO: this should be improved:
+    //   1. if there's an empty workspace on the specified vdesk, we should move the window there;
+    //   2. we should give a way to specify on which workspace to move the window. It'd be best if user could specify 1,2,3
+    //      and we move the window to the first, second or third monitor on the vdesk (from left to right)
+    if (arg == MOVETODESK_DISPATCH_STR) {
+        // TODO: notify about missing args
+        return -1;
+    }
+
+    int  vdeskId;
+    auto vdeskName  = parseMoveDispatch(arg);
+    auto n_monitors = g_pCompositor->m_vMonitors.size();
+    try {
+        vdeskId = std::stoi(vdeskName);
+    } catch (std::exception& _) { vdeskId = getOrCreateDeskIdFromName(vdeskName); }
+
+    if (isVerbose())
+        printLog("creating new vdesk with id " + std::to_string(vdeskId));
+    if (!vdeskNamesMap.contains(vdeskId))
+        vdeskNamesMap[vdeskId] = std::to_string(vdeskId);
+
+    auto vdesk = vdesksMap[vdeskId] = std::make_shared<VirtualDesk>(vdeskId, vdeskNamesMap[vdeskId]);
+
+    // just take the first workspace wherever in the layout
+    auto        wid = vdesk->activeLayout(conf).begin()->second;
+
+    std::string moveCmd;
+    if (arg == "") {
+        moveCmd = std::to_string(wid);
+    } else {
+        moveCmd = std::to_string(wid) + "," + arg;
+    }
+
+    HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + moveCmd);
+    return vdeskId;
+}
+
+int VirtualDeskManager::getOrCreateDeskIdFromName(const std::string& name) {
+    int  max_key = -1;
+    bool found   = false;
+    int  vdesk;
+    for (auto const& [key, val] : vdeskNamesMap) {
+        if (val == name) {
+            vdesk = key;
+            found = true;
+            break;
+        }
+        if (key > max_key)
+            max_key = key;
+    }
+    if (!found) {
+        vdesk                = max_key + 1;
+        vdeskNamesMap[vdesk] = name;
+    }
+    return vdesk;
+}
+
+void VirtualDeskManager::loadLayoutConf() {
+    // Having the possibility to change this at any given time
+    // poses just too many issues to think about for now.
+    // Maybe in a future release :)
+    if (confLoaded)
+        return;
+    static auto* const PREMEMBER_LAYOUT = &HyprlandAPI::getConfigValue(PHANDLE, REMEMBER_LAYOUT_CONF)->intValue;
+    conf                                = layoutConfFromInt(*PREMEMBER_LAYOUT);
+    confLoaded                          = true;
+}
+
+void VirtualDeskManager::cycleWorkspaces() {
+    static auto* const PCYCLEWORKSPACES = &HyprlandAPI::getConfigValue(PHANDLE, CYCLEWORKSPACES_CONF)->intValue;
+    if (!*PCYCLEWORKSPACES)
+        return;
+
+    auto      n_monitors     = g_pCompositor->m_vMonitors.size();
+    CMonitor* currentMonitor = g_pCompositor->m_pLastMonitor;
+
+    // TODO: implement for more than two monitors as well.
+    // This probably requires to compute monitors position
+    // in order to consistently move left/right or up/down.
+    if (n_monitors == 2) {
+        int  other    = g_pCompositor->m_vMonitors[0]->ID == currentMonitor->ID;
+        auto otherMon = g_pCompositor->m_vMonitors[other].get();
+        g_pCompositor->swapActiveWorkspaces(currentMonitor, otherMon);
+
+        auto currentWorkspace = g_pCompositor->getWorkspaceByID(currentMonitor->activeWorkspace);
+        auto otherWorkspace   = g_pCompositor->getWorkspaceByID(otherMon->activeWorkspace);
+        activeVdesk()->changeWorkspaceOnMonitor(currentWorkspace->m_iID, currentMonitor);
+        activeVdesk()->changeWorkspaceOnMonitor(otherWorkspace->m_iID, otherMon);
+    } else if (n_monitors > 2) {
+        printLog("Cycling workspaces is not yet implemented for more than 2 monitors."
+                 "\nIf you would like to have this feature, open an issue on virtual-desktops github repo, or even "
+                 "better, open a PR :)");
+    }
+}
+
+void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks(CMonitor* monitor) {
+    for (const auto& [_, vdesk] : vdesksMap) {
+        // recompute active layout
+        vdesk->activeLayout(conf);
+        vdesk->deleteInvalidMonitor(monitor);
+    }
+}
+
+void VirtualDeskManager::resetAllVdesks() {
+    for (const auto& [_, vdesk] : vdesksMap) {
+        vdesk->resetLayout();
+    }
+}
+
+void VirtualDeskManager::invalidateAllLayouts() {
+    for (const auto& [_, vdesk] : vdesksMap) {
+        vdesk->invalidateActiveLayout();
+    }
+}
+
+CMonitor* VirtualDeskManager::getCurrentMonitor() {
+    CMonitor* currentMonitor = g_pCompositor->m_pLastMonitor;
+    // This can happen when we receive the "on disconnect" signal
+    // let's just take first monitor we can find
+    if (currentMonitor && !currentMonitor->m_bEnabled) {
+        for (std::shared_ptr<CMonitor> mon : g_pCompositor->m_vMonitors) {
+            if (mon->m_bEnabled)
+                return mon.get();
+        }
+        return nullptr;
+    }
+    return currentMonitor;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,8 +56,16 @@ void virtualDeskDispatch(std::string arg) {
     manager->changeActiveDesk(arg, true);
 }
 
-void goPreviousVDeskDispatch(std::string _) {
+void goPreviousVDeskDispatch(std::string) {
     manager->previousDesk();
+}
+
+void goNextVDeskDispatch(std::string) {
+    manager->nextDesk(false);
+}
+
+void cycleVDeskDispatch(std::string) {
+    manager->nextDesk(true);
 }
 
 void moveToDeskDispatch(std::string arg) {
@@ -110,9 +118,14 @@ void printLayoutDispatch(std::string arg) {
     printLog(out.str());
 }
 
-void resetVDeskDispatch(std::string _) {
-    printLog("Resetting all vdesks to default layouts");
-    manager->resetAllVdesks();
+void resetVDeskDispatch(std::string arg) {
+    if (arg.length() == 0) {
+        printLog("Resetting all vdesks to default layouts");
+        manager->resetAllVdesks();
+    } else {
+        printLog("Resetting vdesk " + arg);
+        manager->resetVdesk(arg);
+    }
     manager->applyCurrentVDesk();
 }
 
@@ -172,6 +185,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     HyprlandAPI::addDispatcher(PHANDLE, VDESK_DISPATCH_STR, virtualDeskDispatch);
     HyprlandAPI::addDispatcher(PHANDLE, PREVDESK_DISPATCH_STR, goPreviousVDeskDispatch);
+    HyprlandAPI::addDispatcher(PHANDLE, NEXTDESK_DISPATCH_STR, goNextVDeskDispatch);
+    HyprlandAPI::addDispatcher(PHANDLE, CYCLEVDESK_DISPATCH_STR, cycleVDeskDispatch);
     HyprlandAPI::addDispatcher(PHANDLE, MOVETODESK_DISPATCH_STR, moveToDeskDispatch);
     HyprlandAPI::addDispatcher(PHANDLE, MOVETODESKSILENT_DISPATCH_STR, moveToDeskSilentDispatch);
     HyprlandAPI::addDispatcher(PHANDLE, RESET_VDESK_DISPATCH_STR, resetVDeskDispatch);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addDispatcher(PHANDLE, PRINTLAYOUT_DISPATCH_STR, printLayoutDispatch);
     HyprlandAPI::addConfigValue(PHANDLE, VIRTUALDESK_NAMES_CONF, SConfigValue{.strValue = "unset"});
     HyprlandAPI::addConfigValue(PHANDLE, CYCLEWORKSPACES_CONF, SConfigValue{.intValue = 1});
-    HyprlandAPI::addConfigValue(PHANDLE, REMEMBER_LAYOUT_CONF, SConfigValue{.intValue = 1});
+    HyprlandAPI::addConfigValue(PHANDLE, REMEMBER_LAYOUT_CONF, SConfigValue{.strValue = REMEMBER_SIZE});
     HyprlandAPI::addConfigValue(PHANDLE, NOTIFY_INIT, SConfigValue{.intValue = 1});
     HyprlandAPI::addConfigValue(PHANDLE, VERBOSE_LOGS, SConfigValue{.intValue = 0});
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,31 +6,26 @@
 #include <src/debug/Log.hpp>
 
 #include "globals.hpp"
+#include "VirtualDeskManager.hpp"
+#include "utils.hpp"
 
 #include <any>
 #include <iostream>
 #include <map>
 #include <math.h>
+#include <sstream>
 #include <vector>
 
-static HOOK_CALLBACK_FN*   onWorkspaceChangeHook         = nullptr;
-const std::string          VIRTUALDESK_NAMES_CONF        = "plugin:virtual-desktops:names";
-const std::string          CYCLEWORKSPACES_CONF          = "plugin:virtual-desktops:cycleworkspaces";
-const std::string          VDESK_DISPATCH_STR            = "vdesk";
-const std::string          MOVETODESK_DISPATCH_STR       = "movetodesk";
-const std::string          MOVETODESKSILENT_DISPATCH_STR = "movetodesksilent";
-const std::string          PREVDESK_DISPATCH_STR         = "prevdesk";
-const std::string          PRINTDESK_DISPATCH_STR        = "printdesk";
-std::map<int, std::string> virtualDeskNames              = {{1, "1"}};
-int                        prevVDesk                     = -1;
-int                        currentVDesk                  = 1; // when plugin is launched, we assume we start at vdesk 1
+static HOOK_CALLBACK_FN*            onWorkspaceChangeHook = nullptr;
+static HOOK_CALLBACK_FN*            onMonitorRemovedHook  = nullptr;
+static HOOK_CALLBACK_FN*            onMonitorAddedHook    = nullptr;
+static HOOK_CALLBACK_FN*            onConfigReloadedHook  = nullptr;
+static HOOK_CALLBACK_FN*            onTickHook            = nullptr;
+std::unique_ptr<VirtualDeskManager> manager               = std::make_unique<VirtualDeskManager>();
+bool                                notifiedInit          = false;
+bool                                needsReloading        = false;
 
-void                       printLog(std::string s) {
-    Debug::log(INFO, "[virtual-desktops] %s", s);
-    // std::cout << "[virtual-desktops] " + s << std::endl;
-}
-
-void parseNamesConf(std::string& conf) {
+void                                parseNamesConf(std::string& conf) {
     size_t      pos;
     size_t      delim;
     std::string rule;
@@ -38,14 +33,18 @@ void parseNamesConf(std::string& conf) {
         while ((pos = conf.find(',')) != std::string::npos) {
             rule = conf.substr(0, pos);
             if ((delim = rule.find(':')) != std::string::npos) {
-                int vdeskId               = std::stoi(rule.substr(0, delim));
-                virtualDeskNames[vdeskId] = rule.substr(delim + 1);
+                int vdeskId                     = std::stoi(rule.substr(0, delim));
+                manager->vdeskNamesMap[vdeskId] = rule.substr(delim + 1);
             }
             conf.erase(0, pos + 1);
         }
         if ((delim = conf.find(':')) != std::string::npos) {
-            int vdeskId               = std::stoi(conf.substr(0, delim));
-            virtualDeskNames[vdeskId] = conf.substr(delim + 1);
+            int vdeskId                     = std::stoi(conf.substr(0, delim));
+            manager->vdeskNamesMap[vdeskId] = conf.substr(delim + 1);
+        }
+        // Update current vdesk names
+        for (auto const& [i, vdesk] : manager->vdesksMap) {
+            vdesk->name = manager->vdeskNamesMap[i];
         }
     } catch (std::exception const& ex) {
         // #aa1245
@@ -53,154 +52,28 @@ void parseNamesConf(std::string& conf) {
     }
 }
 
-std::string parseMoveDispatch(std::string& arg) {
-    size_t      pos;
-    std::string vdeskName;
-    if ((pos = arg.find(',')) != std::string::npos) {
-        vdeskName = arg.substr(0, pos);
-        arg.erase(0, pos + 1);
-    } else {
-        vdeskName = arg;
-        arg       = "";
-    }
-    return vdeskName;
-}
-
-void changeVDesk(int vdesk) {
-    if (vdesk == -1) {
-        return;
-    }
-    auto      n_monitors     = g_pCompositor->m_vMonitors.size();
-    CMonitor* currentMonitor = g_pCompositor->m_pLastMonitor;
-    if (!currentMonitor) {
-        printLog("No active monitor!! Not changing vdesk.");
-        return;
-    }
-    printLog("Changing to virtual desktop " + std::to_string(vdesk));
-    static auto* const PCYCLEWORKSPACES = &HyprlandAPI::getConfigValue(PHANDLE, CYCLEWORKSPACES_CONF)->intValue;
-
-    if (vdesk == currentVDesk) {
-        if (!*PCYCLEWORKSPACES)
-            return;
-        // TODO implement for more than two monitors as well.
-        // This probably requires to compute monitors position
-        // in order to consistently move left/right or up/down.
-        if (n_monitors == 2) {
-            int other = g_pCompositor->m_vMonitors[0]->ID == currentMonitor->ID;
-            g_pCompositor->swapActiveWorkspaces(currentMonitor, g_pCompositor->m_vMonitors[other].get());
-        } else if (n_monitors > 2) {
-            printLog("Cycling workspaces is not yet implemented for more than 2 monitors."
-                     "\nIf you would like to have this feature, open an issue on virtual-desktops github repo, or even "
-                     "better, open a PR :)");
-        }
-        return;
-    }
-    auto        vdeskFirstWorkspace = (vdesk - 1) * n_monitors + 1;
-    int         j                   = 0;
-
-    CWorkspace* focusedWorkspace;
-    for (int i = vdeskFirstWorkspace; i < vdeskFirstWorkspace + n_monitors; i++) {
-        CWorkspace* workspace = g_pCompositor->getWorkspaceByID(i);
-        auto        mon       = g_pCompositor->m_vMonitors[j];
-        if (!workspace) {
-            printLog("Creating workspace " + std::to_string(i));
-            workspace = g_pCompositor->createNewWorkspace(i, mon->ID);
-        }
-        // Hack: we change the workspace on the current monitor as our last operation,
-        // so that we also automatically focus it
-        if (mon->ID == currentMonitor->ID) {
-            focusedWorkspace = workspace;
-            j++;
-            continue;
-        }
-        g_pCompositor->m_vMonitors[j]->changeWorkspace(workspace, false);
-        j++;
-    }
-    currentMonitor->changeWorkspace(focusedWorkspace, false);
-}
-
-int getOrCreateDeskIdWithName(const std::string& name) {
-    int  max_key = -1;
-    bool found   = false;
-    int  vdesk;
-    for (auto const& [key, val] : virtualDeskNames) {
-        if (val == name) {
-            vdesk = key;
-            found = true;
-            break;
-        }
-        if (key > max_key)
-            max_key = key;
-    }
-    if (!found) {
-        vdesk                   = max_key + 1;
-        virtualDeskNames[vdesk] = name;
-    }
-    return vdesk;
-}
-
 void virtualDeskDispatch(std::string arg) {
-    static auto* const PVDESKNAMES = &HyprlandAPI::getConfigValue(PHANDLE, VIRTUALDESK_NAMES_CONF)->strValue;
-    parseNamesConf(*PVDESKNAMES);
-    int vdesk;
-    try {
-        vdesk = std::stoi(arg);
-    } catch (std::exception const& ex) { vdesk = getOrCreateDeskIdWithName(arg); }
-    changeVDesk(vdesk);
+    manager->changeActiveDesk(arg, true);
 }
 
 void goPreviousVDeskDispatch(std::string _) {
-    if (prevVDesk == -1) {
-        printLog("There's no previous desk");
-        return;
-    }
-    changeVDesk(prevVDesk);
-}
-
-int moveToDesk(std::string& arg) {
-    // TODO this should be improved:
-    //   1. if there's an empty workspace on the specified vdesk, we should move the window there;
-    //   2. we should give a way to specify on which workspace to move the window. It'd be best if user could specify 1,2,3
-    //      and we move the window to the first, second or third monitor on the vdesk (from left to right)
-    if (arg == MOVETODESK_DISPATCH_STR) {
-        // TODO notify about missing args
-        return -1;
-    }
-
-    int  vdeskId;
-    auto vdeskName  = parseMoveDispatch(arg);
-    auto n_monitors = g_pCompositor->m_vMonitors.size();
-    try {
-        vdeskId = std::stoi(vdeskName);
-    } catch (std::exception& _) { vdeskId = getOrCreateDeskIdWithName(vdeskName); }
-
-    // just take the first workspace of the vdesk
-    auto        wid = (vdeskId * n_monitors) - (n_monitors - 1);
-    std::string moveCmd;
-    if (arg == "") {
-        moveCmd = std::to_string(wid);
-    } else {
-        moveCmd = std::to_string(wid) + "," + arg;
-    }
-
-    HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + moveCmd);
-    return vdeskId;
+    manager->previousDesk();
 }
 
 void moveToDeskDispatch(std::string arg) {
-    changeVDesk(moveToDesk(arg));
+    manager->changeActiveDesk(manager->moveToDesk(arg), true);
 }
 
 void moveToDeskSilentDispatch(std::string arg) {
-    moveToDesk(arg);
+    manager->moveToDesk(arg);
 }
 
 void printVdesk(int vdeskId) {
-    printLog("VDesk " + std::to_string(vdeskId) + ": " + virtualDeskNames[vdeskId]);
+    printLog("VDesk " + std::to_string(vdeskId) + ": " + manager->vdeskNamesMap[vdeskId]);
 }
 
 void printVdesk(std::string name) {
-    for (auto const& [key, val] : virtualDeskNames) {
+    for (auto const& [key, val] : manager->vdeskNamesMap) {
         if (val == name) {
             printLog("Vdesk " + std::to_string(key) + ": " + val);
             return;
@@ -211,8 +84,9 @@ void printVdesk(std::string name) {
 void printVDeskDispatch(std::string arg) {
     static auto* const PVDESKNAMES = &HyprlandAPI::getConfigValue(PHANDLE, VIRTUALDESK_NAMES_CONF)->strValue;
     parseNamesConf(*PVDESKNAMES);
-    if (arg == PRINTDESK_DISPATCH_STR) {
-        printVdesk(currentVDesk);
+
+    if (arg.length() == 0) {
+        printVdesk(manager->activeVdesk()->id);
     } else
         try {
             // maybe id
@@ -223,13 +97,69 @@ void printVDeskDispatch(std::string arg) {
         }
 }
 
+void printLayoutDispatch(std::string arg) {
+    auto               activeDesk = manager->activeVdesk();
+    auto               layout     = activeDesk->activeLayout(manager->conf);
+    std::ostringstream out;
+    out << "Active desk: " << activeDesk->name;
+    out << "\nActive layout size " << layout.size();
+    out << "; Monitors:\n";
+    for (auto const& [desc, wid] : layout) {
+        out << desc << "; Workspace " << wid << "\n";
+    }
+    printLog(out.str());
+}
+
+void resetVDeskDispatch(std::string _) {
+    printLog("Resetting all vdesks to default layouts");
+    manager->resetAllVdesks();
+    manager->applyCurrentVDesk();
+}
+
 void onWorkspaceChange(void*, std::any val) {
-    int  workspaceID = std::any_cast<CWorkspace*>(val)->m_iID;
-    auto n_monitors  = g_pCompositor->m_vMonitors.size();
-    auto newDesk     = ceil((float)workspaceID / (float)n_monitors);
-    if (currentVDesk != newDesk)
-        prevVDesk = currentVDesk;
-    currentVDesk = newDesk;
+    CWorkspace* workspace   = std::any_cast<CWorkspace*>(val);
+    int         workspaceID = std::any_cast<CWorkspace*>(val)->m_iID;
+
+    auto        monitor = g_pCompositor->getMonitorFromID(workspace->m_iMonitorID);
+    if (!monitor || !monitor->m_bEnabled)
+        return;
+
+    manager->activeVdesk()->changeWorkspaceOnMonitor(workspaceID, monitor);
+    if (isVerbose())
+        printLog("workspace changed: workspace id " + std::to_string(workspaceID) + "; on monitor " + std::to_string(workspace->m_iMonitorID));
+}
+
+void onMonitorRemoved(void*, std::any val) {
+    CMonitor* monitor = std::any_cast<CMonitor*>(val);
+    manager->invalidateAllLayouts();
+    manager->deleteInvalidMonitorsOnAllVdesks(monitor);
+    // Doing applyCurrentVDesk() here it's not possible.
+    // It creates a lot of problems with how Hyprland manages monitor
+    // disconnections. The best thing is just to handle this on the next tick
+    needsReloading = true;
+}
+
+void onMonitorAdded(void*, std::any val) {
+    manager->invalidateAllLayouts();
+    manager->applyCurrentVDesk();
+}
+
+void onTick(void*, std::any) {
+    if (needsReloading) {
+        manager->applyCurrentVDesk();
+        needsReloading = false;
+    }
+}
+
+void onConfigReloaded(void*, std::any val) {
+    static auto* const PNOTIFYINIT = &HyprlandAPI::getConfigValue(PHANDLE, NOTIFY_INIT)->intValue;
+    if (*PNOTIFYINIT && !notifiedInit) {
+        HyprlandAPI::addNotification(PHANDLE, "Virtual desk Initialized successfully!", CColor{0.f, 1.f, 1.f, 1.f}, 5000);
+        notifiedInit = true;
+    }
+    static auto* const PVDESKNAMES = &HyprlandAPI::getConfigValue(PHANDLE, VIRTUALDESK_NAMES_CONF)->strValue;
+    parseNamesConf(*PVDESKNAMES);
+    manager->loadLayoutConf();
 }
 
 // Do NOT change this function.
@@ -244,17 +174,22 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addDispatcher(PHANDLE, PREVDESK_DISPATCH_STR, goPreviousVDeskDispatch);
     HyprlandAPI::addDispatcher(PHANDLE, MOVETODESK_DISPATCH_STR, moveToDeskDispatch);
     HyprlandAPI::addDispatcher(PHANDLE, MOVETODESKSILENT_DISPATCH_STR, moveToDeskSilentDispatch);
+    HyprlandAPI::addDispatcher(PHANDLE, RESET_VDESK_DISPATCH_STR, resetVDeskDispatch);
     HyprlandAPI::addDispatcher(PHANDLE, PRINTDESK_DISPATCH_STR, printVDeskDispatch);
+    HyprlandAPI::addDispatcher(PHANDLE, PRINTLAYOUT_DISPATCH_STR, printLayoutDispatch);
     HyprlandAPI::addConfigValue(PHANDLE, VIRTUALDESK_NAMES_CONF, SConfigValue{.strValue = "unset"});
     HyprlandAPI::addConfigValue(PHANDLE, CYCLEWORKSPACES_CONF, SConfigValue{.intValue = 1});
+    HyprlandAPI::addConfigValue(PHANDLE, REMEMBER_LAYOUT_CONF, SConfigValue{.intValue = 1});
+    HyprlandAPI::addConfigValue(PHANDLE, NOTIFY_INIT, SConfigValue{.intValue = 1});
+    HyprlandAPI::addConfigValue(PHANDLE, VERBOSE_LOGS, SConfigValue{.intValue = 0});
 
     onWorkspaceChangeHook = HyprlandAPI::registerCallbackDynamic(PHANDLE, "workspace", onWorkspaceChange);
+    onMonitorRemovedHook  = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorRemoved", onMonitorRemoved);
+    onMonitorAddedHook    = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorAdded", onMonitorAdded);
+    onConfigReloadedHook  = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", onConfigReloaded);
+    onTickHook            = HyprlandAPI::registerCallbackDynamic(PHANDLE, "tick", onTick);
+
+    // Initialize first vdesk
     HyprlandAPI::reloadConfig();
-    HyprlandAPI::addNotification(PHANDLE, "Virtual desk Initialized successfully!", CColor{0.f, 1.f, 1.f, 1.f}, 5000);
-
-    return {"virtual-desktops", "Virtual desktop like workspaces", "LevMyskin", "1.0"};
-}
-
-APICALL EXPORT void PLUGIN_EXIT() {
-    virtualDeskNames.clear();
+    return {"virtual-desktops", "Virtual desktop like workspaces", "LevMyskin", "2.0b"};
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,8 +1,10 @@
 #include "utils.hpp"
 
-void printLog(std::string s) {
-    // Debug::log(INFO, "[virtual-desktops] %s", s);
+void printLog(std::string s, LogLevel level) {
+#ifdef DEBUG
     std::cout << "[virtual-desktops] " + s << std::endl;
+#endif
+    Debug::log(level, "[virtual-desktops] %s", s);
 }
 
 std::string parseMoveDispatch(std::string& arg) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -23,10 +23,18 @@ std::string parseMoveDispatch(std::string& arg) {
 RememberLayoutConf layoutConfFromInt(const int64_t i) {
     switch (i) {
         case 0: return RememberLayoutConf::none;
-        case 1: return RememberLayoutConf::layout;
+        case 1: return RememberLayoutConf::size;
         case 2: return RememberLayoutConf::monitors;
-        default: return RememberLayoutConf::layout;
+        default: return RememberLayoutConf::size;
     }
+}
+
+RememberLayoutConf layoutConfFromString(const std::string& conf) {
+    if (conf == REMEMBER_NONE)
+        return RememberLayoutConf::none;
+    else if (conf == REMEMBER_SIZE)
+        return RememberLayoutConf::size;
+    return RememberLayoutConf::monitors;
 }
 
 bool isVerbose() {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,33 @@
+#include "utils.hpp"
+
+void printLog(std::string s) {
+    // Debug::log(INFO, "[virtual-desktops] %s", s);
+    std::cout << "[virtual-desktops] " + s << std::endl;
+}
+
+std::string parseMoveDispatch(std::string& arg) {
+    size_t      pos;
+    std::string vdeskName;
+    if ((pos = arg.find(',')) != std::string::npos) {
+        vdeskName = arg.substr(0, pos);
+        arg.erase(0, pos + 1);
+    } else {
+        vdeskName = arg;
+        arg       = "";
+    }
+    return vdeskName;
+}
+
+RememberLayoutConf layoutConfFromInt(const int64_t i) {
+    switch (i) {
+        case 0: return RememberLayoutConf::none;
+        case 1: return RememberLayoutConf::layout;
+        case 2: return RememberLayoutConf::monitors;
+        default: return RememberLayoutConf::layout;
+    }
+}
+
+bool isVerbose() {
+    static auto* const PVERBOSELOGS = &HyprlandAPI::getConfigValue(PHANDLE, VERBOSE_LOGS)->intValue;
+    return *PVERBOSELOGS;
+}


### PR DESCRIPTION
# Virtual desk 2.0
Version 2.0 introduces some new features and dispatches that make this plugin just a little more than a C++ script.
Mainly:

- Remembering workspace changes: i.e., you're on virtual desktop (vdesk) 1, with workspace 1 and 2. You focus workspace 4 replacing workspace 1. if you move to another vdesk 2, and then come back to vdesk 1, you'll get back workspace 2 and 4.
  - These workspace "layouts" are remembered even if you disconnect a monitor and then reconnect it;
- It is possible to remember these "layouts" by number of monitors (a) or by set of specific monitors (b), e.g.:  
   a) if a previous workspaces layout for 2 monitors is found, then that layout will be applied;
   b) if a previous workspaces layout for monitor X and monitor Y is found, then that layout will be applied. In case there are two monitors X and Z, the layout won't be applied and you'll get back the default set of workspaces for the current vdesk.

These "layouts" are *NOT* permanent, and are destroyed once you close the Hyprland session (i.e., you restart/shutdown your pc or simply logout back to your DM).
More information will be given in the new release notes (and the README) once this is ready to merge.

**NOTICE**: the old Virtual Desk behaviour (i.e., you always get workspace 1 and 2 on vdesk 1, even if you change them) will be achievable by calling a new dispatcher `vdeskreset` before moving between vdesks. If you don't like this, please use the 1.0 branch that I'll create before merging this. I'll try to backport critical fixes to that branch if anyone's interested.

## Roadmap
- [ ] Better handling of workspaces and apps on monitor disconnect / reconnect;
- [x] Remember workspace on vdesks:
    - [x]  remember monitor layouts by size;
    - [x]  remember monitor layouts by specific model;
- [x] dispatch to reset default behaviour;
- [x] dispatch to cycle vdesks. Issue #1  
