### PR TITLE
Fix Vdesk recomputation on monitor layout change. Fixes #3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PLUGIN_NAME=virtual-desktops
 
 SOURCE_FILES=$(wildcard src/*.cpp)
 
-COMPILE_FLAGS=-g -fPIC --no-gnu-unique -std=c++23
+COMPILE_FLAGS=-g -fPIC --no-gnu-unique -std=c++23 -Wall
 COMPILE_FLAGS+=-I "/usr/include/pixman-1"
 COMPILE_FLAGS+=-I "/usr/include/libdrm"
 COMPILE_FLAGS+=-I "${HYPRLAND_HEADERS}"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   - [Install](#install)
   - [Help, Hyprland is being weird!](#help-hyprland-is-being-weird)
     - [It's actually the plugin 😱](#its-actually-the-plugin-)
-    - [Thanks to](#thanks-to)
+  - [Thanks to](#thanks-to)
 
 
 ## What is this exactly?
@@ -186,6 +186,6 @@ I've noticed that, sometimes, when disconnecting or reconnecting monitors, there
 If instead you're seeing weird behaviour with the plugin itself, remember you can always run:  
 `hyprtl dispatch vdeskreset`
 
-### Thanks to
+## Thanks to
 [split-workspaces](https://github.com/Duckonaut/split-monitor-workspaces/), from which I borrowed the Makefile, 
 and the general idea of how to write Hyprland plugins.

--- a/include/VirtualDesk.hpp
+++ b/include/VirtualDesk.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifndef VDESK_H
 #define VDESK_H
 
 #include <string>
@@ -9,10 +10,11 @@
 #include <src/helpers/Monitor.hpp>
 #include "globals.hpp"
 #include "utils.hpp"
+#include <src/Compositor.hpp>
 
-typedef std::unordered_map<int, int>         WorkspaceMap;
-typedef std::unordered_map<std::string, int> Layout;
-typedef std::string                          MonitorName;
+typedef std::unordered_map<int, int>             WorkspaceMap;
+typedef std::unordered_map<const CMonitor*, int> Layout;
+typedef std::string                              MonitorName;
 
 /* 
 * Each virtual desk holds a list of layouts. Layouts remember which workspace was on which monitor 
@@ -27,22 +29,22 @@ class VirtualDesk {
     std::string                      name;
     std::vector<Layout>              layouts;
 
-    const Layout&                    activeLayout(const RememberLayoutConf&);
-    Layout&                          searchActiveLayout(const RememberLayoutConf&);
+    const Layout&                    activeLayout(const RememberLayoutConf&, const CMonitor* exclude = nullptr);
+    Layout&                          searchActiveLayout(const RememberLayoutConf&, const CMonitor* exclude = nullptr);
     std::unordered_set<std::string>  setFromMonitors(const std::vector<std::shared_ptr<CMonitor>>&);
     void                             changeWorkspaceOnMonitor(int, CMonitor*);
     void                             invalidateActiveLayout();
     void                             resetLayout();
-    void                             deleteInvalidMonitor(const wlr_output*);
-    void                             deleteInvalidMonitor();
-    void                             deleteInvalidMonitorOnAllLayouts(const wlr_output*);
+    CMonitor*                        deleteInvalidMonitor(const CMonitor*);
+    void                             deleteInvalidMonitorsOnActiveLayout();
+    void                             deleteInvalidMonitorOnAllLayouts(const CMonitor*);
     static std::shared_ptr<CMonitor> firstAvailableMonitor(const std::vector<std::shared_ptr<CMonitor>>&);
 
   private:
-    int                                           m_activeLayout_idx;
-    bool                                          activeIsValid = false;
-    Layout                                        generateCurrentMonitorLayout();
-    static std::vector<std::shared_ptr<CMonitor>> currentlyEnabledMonitors();
-    static std::string                            monitorDesc(const wlr_output*);
-    void                                          checkAndAdaptLayout(Layout*);
+    int                m_activeLayout_idx;
+    bool               activeIsValid = false;
+    Layout             generateCurrentMonitorLayout();
+    static std::string monitorDesc(const CMonitor*);
+    void               checkAndAdaptLayout(Layout*, const CMonitor* exclude = nullptr);
 };
+#endif

--- a/include/VirtualDesk.hpp
+++ b/include/VirtualDesk.hpp
@@ -23,24 +23,26 @@ typedef std::string                          MonitorName;
 class VirtualDesk {
   public:
     VirtualDesk(int id = 1, std::string name = "1");
-    int                             id;
-    std::string                     name;
-    std::vector<Layout>             layouts;
+    int                              id;
+    std::string                      name;
+    std::vector<Layout>              layouts;
 
-    const Layout&                   activeLayout(const RememberLayoutConf&);
-    Layout&                         searchActiveLayout(const RememberLayoutConf&);
-    std::unordered_set<std::string> setFromMonitors(const std::vector<std::shared_ptr<CMonitor>>&);
-    void                            changeWorkspaceOnMonitor(int, CMonitor*);
-    void                            invalidateActiveLayout();
-    void                            resetLayout();
-    void                            deleteInvalidMonitor(CMonitor*);
-    void                            deleteInvalidMonitorOnAllLayouts(CMonitor*);
+    const Layout&                    activeLayout(const RememberLayoutConf&);
+    Layout&                          searchActiveLayout(const RememberLayoutConf&);
+    std::unordered_set<std::string>  setFromMonitors(const std::vector<std::shared_ptr<CMonitor>>&);
+    void                             changeWorkspaceOnMonitor(int, CMonitor*);
+    void                             invalidateActiveLayout();
+    void                             resetLayout();
+    void                             deleteInvalidMonitor(const wlr_output*);
+    void                             deleteInvalidMonitor();
+    void                             deleteInvalidMonitorOnAllLayouts(const wlr_output*);
+    static std::shared_ptr<CMonitor> firstAvailableMonitor(const std::vector<std::shared_ptr<CMonitor>>&);
 
   private:
-    int                                    m_activeLayout_idx;
-    bool                                   activeIsValid = false;
-    Layout                                 generateCurrentMonitorLayout();
-    std::vector<std::shared_ptr<CMonitor>> currentlyEnabledMonitors();
-    static std::string                     monitorDesc(const CMonitor&);
-    void                                   checkAndAdaptLayout(Layout*);
+    int                                           m_activeLayout_idx;
+    bool                                          activeIsValid = false;
+    Layout                                        generateCurrentMonitorLayout();
+    static std::vector<std::shared_ptr<CMonitor>> currentlyEnabledMonitors();
+    static std::string                            monitorDesc(const wlr_output*);
+    void                                          checkAndAdaptLayout(Layout*);
 };

--- a/include/VirtualDeskManager.hpp
+++ b/include/VirtualDeskManager.hpp
@@ -24,7 +24,9 @@ class VirtualDeskManager {
     void                                                  invalidateAllLayouts();
     void                                                  resetAllVdesks();
     void                                                  resetVdesk(const std::string& arg);
-    void                                                  deleteInvalidMonitorsOnAllVdesks(CMonitor*);
+    void                                                  deleteInvalidMonitorsOnAllVdesks(const CMonitor*);
+    void                                                  deleteInvalidMonitorsOnAllVdesks(const wlr_output*);
+    void                                                  deleteInvalidMonitorsOnAllVdesks();
 
   private:
     int       m_activeDeskKey = 1;

--- a/include/VirtualDeskManager.hpp
+++ b/include/VirtualDeskManager.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#ifndef VDESK_MANAGER_H
 #define VDESK_MANAGER_H
 
 #include "VirtualDesk.hpp"
@@ -25,7 +26,6 @@ class VirtualDeskManager {
     void                                                  resetAllVdesks();
     void                                                  resetVdesk(const std::string& arg);
     void                                                  deleteInvalidMonitorsOnAllVdesks(const CMonitor*);
-    void                                                  deleteInvalidMonitorsOnAllVdesks(const wlr_output*);
     void                                                  deleteInvalidMonitorsOnAllVdesks();
 
   private:
@@ -35,3 +35,4 @@ class VirtualDeskManager {
     int       getDeskIdFromName(const std::string& name, bool createIfNotFound = true);
     CMonitor* getCurrentMonitor();
 };
+#endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#ifndef UTILS_H
 #define UTILS_H
 
 #include "src/debug/Log.hpp"
 #include "globals.hpp"
 #include "src/config/ConfigManager.hpp"
 #include <string>
+#include "src/Compositor.hpp"
 
 const std::string VIRTUALDESK_NAMES_CONF        = "plugin:virtual-desktops:names";
 const std::string CYCLEWORKSPACES_CONF          = "plugin:virtual-desktops:cycleworkspaces";
@@ -32,10 +34,12 @@ enum RememberLayoutConf {
     monitors = 2
 };
 
-RememberLayoutConf layoutConfFromInt(const int64_t);
-RememberLayoutConf layoutConfFromString(const std::string& conf);
-void               printLog(std::string s, LogLevel level = INFO);
+RememberLayoutConf                     layoutConfFromInt(const int64_t);
+RememberLayoutConf                     layoutConfFromString(const std::string& conf);
+void                                   printLog(std::string s, LogLevel level = INFO);
 
-std::string        parseMoveDispatch(std::string& arg);
+std::string                            parseMoveDispatch(std::string& arg);
+std::vector<std::shared_ptr<CMonitor>> currentlyEnabledMonitors(const CMonitor* exclude = nullptr);
 
-bool               isVerbose();
+bool                                   isVerbose();
+#endif

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -1,5 +1,6 @@
 #include "VirtualDeskManager.hpp"
 #include <src/Compositor.hpp>
+#include <format>
 
 VirtualDeskManager::VirtualDeskManager() {
     this->conf       = RememberLayoutConf::size;
@@ -58,20 +59,29 @@ void VirtualDeskManager::nextDesk(bool cycle) {
 }
 
 void VirtualDeskManager::applyCurrentVDesk() {
-    if (isVerbose())
-        printLog("applying vdesk" + activeVdesk()->name);
-    auto currentMonitor = getCurrentMonitor();
-    if (!currentMonitor) {
+    if (currentlyEnabledMonitors().size() == 0) {
         printLog("There are no monitors!");
         return;
     }
+    if (isVerbose())
+        printLog("applying vdesk" + activeVdesk()->name);
+    auto currentMonitor = getCurrentMonitor();
+    // if (!currentMonitor) {
+    //     printLog("There are no monitors!");
+    //     return;
+    // }
     auto        layout = activeVdesk()->activeLayout(conf);
     CWorkspace* focusedWorkspace;
-    for (auto const& [monitorDesc, workspaceId] : layout) {
-        CMonitor* mon = g_pCompositor->getMonitorFromDesc(monitorDesc);
-        if (!mon) {
-            printLog("There is no monitor with description " + monitorDesc);
-            continue;
+    for (auto [lmon, workspaceId] : layout) {
+        CMonitor* mon = g_pCompositor->getMonitorFromID(lmon->ID);
+        if (!lmon || !lmon->m_bEnabled) {
+            printLog("One of the monitors in the vdesk went bonkers...Will try to find another one");
+            mon = activeVdesk()->deleteInvalidMonitor(lmon);
+            // Big F, we can't do much here
+            if (!mon) {
+                printLog("There is no enabled monitor at all. I give up :)");
+                return;
+            }
         }
         CWorkspace* workspace = g_pCompositor->getWorkspaceByID(workspaceId);
         if (!workspace) {
@@ -189,10 +199,12 @@ void VirtualDeskManager::cycleWorkspaces() {
     }
 }
 
-void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks(const wlr_output* monitor) {
+void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks(const CMonitor* monitor) {
     for (const auto& [_, vdesk] : vdesksMap) {
         // recompute active layout
-        vdesk->activeLayout(conf);
+        vdesk->activeLayout(conf, monitor);
+        if (monitor)
+            printLog(std::format("Deleting monitor with exclude {}", monitor->szName));
         vdesk->deleteInvalidMonitor(monitor);
     }
 }
@@ -201,12 +213,8 @@ void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks() {
     for (const auto& [_, vdesk] : vdesksMap) {
         // recompute active layout
         vdesk->activeLayout(conf);
-        vdesk->deleteInvalidMonitor();
+        vdesk->deleteInvalidMonitorsOnActiveLayout();
     }
-}
-
-void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks(const CMonitor* monitor) {
-    deleteInvalidMonitorsOnAllVdesks(monitor->output);
 }
 
 void VirtualDeskManager::resetAllVdesks() {

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -105,8 +105,7 @@ int VirtualDeskManager::moveToDesk(std::string& arg) {
     }
 
     int  vdeskId;
-    auto vdeskName  = parseMoveDispatch(arg);
-    auto n_monitors = g_pCompositor->m_vMonitors.size();
+    auto vdeskName = parseMoveDispatch(arg);
     try {
         vdeskId = std::stoi(vdeskName);
     } catch (std::exception& _) { vdeskId = getDeskIdFromName(vdeskName); }
@@ -190,12 +189,24 @@ void VirtualDeskManager::cycleWorkspaces() {
     }
 }
 
-void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks(CMonitor* monitor) {
+void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks(const wlr_output* monitor) {
     for (const auto& [_, vdesk] : vdesksMap) {
         // recompute active layout
         vdesk->activeLayout(conf);
         vdesk->deleteInvalidMonitor(monitor);
     }
+}
+
+void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks() {
+    for (const auto& [_, vdesk] : vdesksMap) {
+        // recompute active layout
+        vdesk->activeLayout(conf);
+        vdesk->deleteInvalidMonitor();
+    }
+}
+
+void VirtualDeskManager::deleteInvalidMonitorsOnAllVdesks(const CMonitor* monitor) {
+    deleteInvalidMonitorsOnAllVdesks(monitor->output);
 }
 
 void VirtualDeskManager::resetAllVdesks() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ static HOOK_CALLBACK_FN*            onWorkspaceChangeHook = nullptr;
 static HOOK_CALLBACK_FN*            onMonitorRemovedHook  = nullptr;
 static HOOK_CALLBACK_FN*            onMonitorAddedHook    = nullptr;
 static HOOK_CALLBACK_FN*            onConfigReloadedHook  = nullptr;
-static HOOK_CALLBACK_FN*            onTickHook            = nullptr;
+static HOOK_CALLBACK_FN*            onPreRenderHook       = nullptr;
 std::unique_ptr<VirtualDeskManager> manager               = std::make_unique<VirtualDeskManager>();
 bool                                notifiedInit          = false;
 bool                                needsReloading        = false;
@@ -157,7 +157,7 @@ void onMonitorAdded(void*, SCallbackInfo&, std::any val) {
     needsReloading = true;
 }
 
-void onTick(void*, SCallbackInfo&, std::any) {
+void onPreRender(void*, SCallbackInfo&, std::any) {
     if (needsReloading) {
         manager->applyCurrentVDesk();
         needsReloading = false;
@@ -202,7 +202,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     onMonitorRemovedHook  = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorRemoved", onMonitorRemoved);
     onMonitorAddedHook    = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorAdded", onMonitorAdded);
     onConfigReloadedHook  = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", onConfigReloaded);
-    onTickHook            = HyprlandAPI::registerCallbackDynamic(PHANDLE, "tick", onTick);
+    onPreRenderHook       = HyprlandAPI::registerCallbackDynamic(PHANDLE, "preRender", onPreRender);
 
     // Initialize first vdesk
     HyprlandAPI::reloadConfig();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,10 +1,10 @@
 #include "utils.hpp"
 
 void printLog(std::string s, LogLevel level) {
-#ifdef DEBUG
-    std::cout << "[virtual-desktops] " + s << std::endl;
-#endif
-    Debug::log(level, "[virtual-desktops] %s", s);
+    // #ifdef DEBUG
+    //     std::cout << "[virtual-desktops] " + s << std::endl;
+    // #endif
+    Debug::log(level, "[virtual-desktops] {}", s);
 }
 
 std::string parseMoveDispatch(std::string& arg) {
@@ -40,4 +40,24 @@ RememberLayoutConf layoutConfFromString(const std::string& conf) {
 bool isVerbose() {
     static auto* const PVERBOSELOGS = &HyprlandAPI::getConfigValue(PHANDLE, VERBOSE_LOGS)->intValue;
     return *PVERBOSELOGS;
+}
+
+std::vector<std::shared_ptr<CMonitor>> currentlyEnabledMonitors(const CMonitor* exclude) {
+    std::vector<std::shared_ptr<CMonitor>> monitors;
+    std::copy_if(g_pCompositor->m_vMonitors.begin(), g_pCompositor->m_vMonitors.end(), std::back_inserter(monitors), [&](auto mon) {
+        if (g_pCompositor->m_pUnsafeOutput && g_pCompositor->m_pUnsafeOutput->szName == mon->szName)
+            return false;
+
+        if (!mon->output)
+            return false;
+
+        if (mon->output->name == std::string("HEADLESS-1"))
+            return false;
+
+        if (mon.get() == exclude)
+            return false;
+
+        return mon->m_bEnabled;
+    });
+    return monitors;
 }


### PR DESCRIPTION
This PR moves the plugin code from listening to monitor ticks, to actually using Hyprland function hooks.  
When a monitor is plugged/disconnected, this allows to immediately recompute the correct vdesk layout to apply, removing much of the headaches I've got so far with this problem (this closes #3).

I'll test it with different monitor layouts and then merge + close this PR. 