### PR TITLE
Add NixOS and home-manager support via flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 compile_flags.txt
 compile_commands.json
 .cache
+result/

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Once compiled, you can tell Hyprland to load the plugin as described in the [Hyp
 
 ### Installing on NixOS with home—manager
 
-Here is an example flake that you can use to add hyprland-virtual-desktops to your configuration
+Here is an example flake that you can modify to add hyprland-virtual-desktops to your configuration
 ```nix
 # flake.nix
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
     - [Choosing how to remember, or choosing to forget](#choosing-how-to-remember-or-choosing-to-forget)
       - [Example](#example-2)
   - [Install](#install)
+    - [Installing on NixOS with home—manager](#installing-on-nixos-with-homemanager)
   - [Help, Hyprland is being weird!](#help-hyprland-is-being-weird)
     - [It's actually the plugin 😱](#its-actually-the-plugin-)
   - [Thanks to](#thanks-to)
@@ -222,6 +223,81 @@ this will compile and copy the compiled `.so` plugin in the `$HOME/.local/share/
 You can also use `make virtual-desktops.so` to output the compiled plugin in the repo directory.
 
 Once compiled, you can tell Hyprland to load the plugin as described in the [Hyprland wiki](https://wiki.hyprland.org/Plugins/Using-Plugins/#installing--using-plugins).
+
+
+### Installing on NixOS with home—manager
+
+Here is an example flake that you can use to add hyprland-virtual-desktops to your configuration
+```nix
+# flake.nix
+
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    hyprland.url = "github:hyprwm/Hyprland";
+
+    hyprland-virtual-desktops = {
+      url = "github:levnikmyskin/hyprland-virtual-desktops";
+      inputs.hyprland.follows = "hyprland"; # We want to build against the same version of hyprland that we are using
+    };
+        
+  };
+
+  outputs = { nixpkgs, home-manager, hyprland, hyprland-virtual-desktops, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      homeConfigurations."user@hostname" = home-manager.lib.homeManagerConfiguration {
+        pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+        # You can optionally move this module to its own .nix file and source it
+        # here if you want to modularise your configuration
+        modules = [
+          hyprland.homeManagerModules.default
+          {
+            wayland.windowManager.hyprland = {
+              enable = true;
+              package = hyprland.packages."${pkgs.system}".hyprland;
+              plugins = [
+                hyprland-virtual-desktops.packages.${pkgs.system}.virtual-desktops
+              ];
+              # extraConfig is a string that becomes hyprland.conf
+              extraConfig = ''
+                stickyrule = class:^(kittysticky)$,3
+                stickyrule = title:thunderbird,mail
+
+                plugin {
+                    virtual-desktops {
+                        names = 1:coding, 2:internet, 3:mail and chats 
+                        cycleworkspaces = 1
+                        rememberlayout = size
+                        notifyinit = 0
+                        verbose_logging = 0
+                    }
+                }
+              '' + ''
+                # your other configuration for hyprland
+              '';
+            };
+          }
+          # ...
+          # NOTE:
+          # You will want to enable the Hyprland module in your NixOS configuration
+          # too, since that also enables critical components like xdg-desktop-portal,
+          # xwayland, polkit, etc
+        ];
+      };
+    };
+}
+```
 
 ## Help, Hyprland is being weird!
 I've noticed that, sometimes, when disconnecting or reconnecting monitors, there might be weird artifacts or similar. Try running:  

--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ Here is an example flake that you can modify to add hyprland-virtual-desktops to
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    hyprland.url = "github:hyprwm/Hyprland";
-
-    hyprland-virtual-desktops = {
-      url = "github:levnikmyskin/hyprland-virtual-desktops";
-      inputs.hyprland.follows = "hyprland"; # We want to build against the same version of hyprland that we are using
+    hyprland = {
+      url = "github:hyprwm/Hyprland";
+      follows = "hyprland-virtual-desktops"; # We make sure we use the version that is known to be compatable with hyprland-virtual-desktops
     };
+
+    hyprland-virtual-desktops.url = "github:levnikmyskin/hyprland-virtual-desktops";
         
   };
 

--- a/README.md
+++ b/README.md
@@ -239,14 +239,13 @@ Here is an example flake that you can modify to add hyprland-virtual-desktops to
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
+   
     hyprland = {
       url = "github:hyprwm/Hyprland";
-      follows = "hyprland-virtual-desktops"; # We make sure we use the version that is known to be compatable with hyprland-virtual-desktops
+      follows = "hyprland-virtual-desktops/hyprland"; # To make sure we run the same version of hyprland that the plugin was built against
     };
-
-    hyprland-virtual-desktops.url = "github:levnikmyskin/hyprland-virtual-desktops";
-        
+    hyprland-virtual-desktops.url = "github:wiillou/hyprland-virtual-desktops";
+    
   };
 
   outputs = { nixpkgs, home-manager, hyprland, hyprland-virtual-desktops, ... }:
@@ -265,7 +264,7 @@ Here is an example flake that you can modify to add hyprland-virtual-desktops to
           {
             wayland.windowManager.hyprland = {
               enable = true;
-              package = hyprland.packages."${pkgs.system}".hyprland;
+              package = hyprland.packages.${pkgs.system}.hyprland;
               plugins = [
                 hyprland-virtual-desktops.packages.${pkgs.system}.virtual-desktops
               ];
@@ -293,6 +292,12 @@ Here is an example flake that you can modify to add hyprland-virtual-desktops to
           # You will want to enable the Hyprland module in your NixOS configuration
           # too, since that also enables critical components like xdg-desktop-portal,
           # xwayland, polkit, etc
+          # 
+          # # Have this somewhere in your NixOS configuration
+          # programs.hyprland = {
+          #   enabled = true;
+          #   package = inputs.hyprland.packages.${pkgs.system}.hyprland;
+          # };
         ];
       };
     };

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,185 @@
+{
+  "nodes": {
+    "hyprland": {
+      "inputs": {
+        "hyprland-protocols": "hyprland-protocols",
+        "hyprlang": "hyprlang",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "wlroots": "wlroots",
+        "xdph": "xdph"
+      },
+      "locked": {
+        "lastModified": 1709080360,
+        "narHash": "sha256-oZe4k6jtO/0govmERGcbeyvE9EfTvXY5bnyIs6AsL9U=",
+        "owner": "hyprwm",
+        "repo": "Hyprland",
+        "rev": "1c460e98f870676b15871fe4e5bfeb1a32a3d6d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "ref": "v0.36.0",
+        "repo": "Hyprland",
+        "type": "github"
+      }
+    },
+    "hyprland-protocols": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1691753796,
+        "narHash": "sha256-zOEwiWoXk3j3+EoF3ySUJmberFewWlagvewDRuWYAso=",
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "rev": "0c2ce70625cb30aef199cb388f99e19a61a6ce03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
+    "hyprlang": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708787654,
+        "narHash": "sha256-7ACgM3ZuAhPqurXHUvR2nWMRcnmzGGPjLK6q4DSTelI=",
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "rev": "0fce791ba2334aca183f2ed42399518947550d0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708807242,
+        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "hyprland": "hyprland",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "wlroots": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.freedesktop.org",
+        "lastModified": 1708558866,
+        "narHash": "sha256-Mz6hCtommq7RQfcPnxLINigO4RYSNt23HeJHC6mVmWI=",
+        "owner": "wlroots",
+        "repo": "wlroots",
+        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.freedesktop.org",
+        "owner": "wlroots",
+        "repo": "wlroots",
+        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
+        "type": "gitlab"
+      }
+    },
+    "xdph": {
+      "inputs": {
+        "hyprland-protocols": [
+          "hyprland",
+          "hyprland-protocols"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708696469,
+        "narHash": "sha256-shh5wmpeYy3MmsBfkm4f76yPsBDGk6OLYRVG+ARy2F0=",
+        "owner": "hyprwm",
+        "repo": "xdg-desktop-portal-hyprland",
+        "rev": "1b713911c2f12b96c2574474686e4027ac4bf826",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "xdg-desktop-portal-hyprland",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
 
         installPhase = ''
           mkdir -p $out/lib
-          cp virtual-desktops.so $out/lib/
+          cp virtual-desktops.so $out/lib/libvirtual-desktops.so
         '';
 
         meta = with pkgs.lib; {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "A plugin for the Hyprland compositor, implementing virtual-desktop functionality.";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.hyprland.url = "github:hyprwm/Hyprland";
+
+  outputs = { self, nixpkgs, hyprland }:
+    let
+      # Helper function to create packages for each system
+      withPkgsFor = fn: nixpkgs.lib.genAttrs (builtins.attrNames hyprland.packages) (system: fn system nixpkgs.legacyPackages.${system});
+      virtualDesktops = withPkgsFor (system: pkgs: pkgs.gcc13Stdenv.mkDerivation rec {
+        pname = "virtual-desktops";
+        version = "2.2.0";
+        src = ./.;
+
+        buildFlags = [ "-shared" "-g" "-fPIC" "--no-gnu-unique" "-std=c++23" "-Wall" ];
+        buildFlagsArray = buildFlags ++ [ "-Iinclude" "-DWLR_USE_UNSTABLE" ];
+        
+        inherit (hyprland.packages.${system}.hyprland) nativeBuildInputs;
+
+        buildInputs = [ hyprland.packages.${system}.hyprland ] ++ hyprland.packages.${system}.hyprland.buildInputs;
+
+        # Skip meson phases
+        configurePhase = "true";
+        mesonConfigurePhase  = "true";
+        mesonBuildPhase = "true";
+        mesonInstallPhase = "true";
+
+        buildPhase = ''
+          make all
+        '';
+
+        installPhase = ''
+          mkdir -p $out/lib
+          cp virtual-desktops.so $out/lib/
+        '';
+
+        meta = with pkgs.lib; {
+          homepage = "https://github.com/levnikmyskin/hyprland-virtual-desktops";
+          description = "A plugin for the Hyprland compositor, implementing virtual-desktop functionality.";
+          license = licenses.bsd3;
+          platforms = platforms.linux;
+        };
+      });
+    in
+    {
+      packages = withPkgsFor (system: pkgs: rec {
+        virtual-desktops = virtualDesktops.${system};
+        default = virtual-desktops;
+      });
+
+      devShells = withPkgsFor (system: pkgs: {
+        default = pkgs.mkShell.override { stdenv = pkgs.gcc13Stdenv; } {
+          name = "virtual-desktops";
+          buildInputs = [ hyprland.packages.${system}.hyprland ];
+          inputsFrom = [ hyprland.packages.${system}.hyprland ];
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A plugin for the Hyprland compositor, implementing virtual-desktop functionality.";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  inputs.hyprland.url = "github:hyprwm/Hyprland";
+  inputs.hyprland.url = "github:hyprwm/Hyprland/v0.36.0";
 
   outputs = { self, nixpkgs, hyprland }:
     let


### PR DESCRIPTION
Added support for building the plugin via flake, and using it in a declarative home-manager configuration. Added details about how to do this in the README, with an example flake to demonstrate.

Closes #6 