### PR TITLE
Build for Hyprland v0.40

### DIFF
--- a/include/sticky_apps.hpp
+++ b/include/sticky_apps.hpp
@@ -4,6 +4,7 @@
 #define STICKYAPPS_H
 #include <string>
 #include <VirtualDeskManager.hpp>
+#include <hyprland/src/defines.hpp>
 
 const std::string TITLE         = "title";
 const std::string INITIAL_TITLE = "initialTitle";
@@ -23,10 +24,9 @@ namespace StickyApps {
 
     void              matchRules(const std::vector<SStickyRule>&, std::unique_ptr<VirtualDeskManager>&);
 
-    int               matchRuleOnWindow(const std::vector<SStickyRule>&, std::unique_ptr<VirtualDeskManager>&, CWindow*);
+    int               matchRuleOnWindow(const std::vector<SStickyRule>&, std::unique_ptr<VirtualDeskManager>&, PHLWINDOW);
 
-    const std::string extractProperty(const SStickyRule&, std::unique_ptr<CWindow>&);
-    const std::string extractProperty(const SStickyRule&, CWindow*);
+    const std::string extractProperty(const SStickyRule&, PHLWINDOW);
 
     bool              ruleMatch(const std::string&, const std::string&);
 }

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -114,7 +114,7 @@ int VirtualDeskManager::moveToDesk(std::string& arg, int vdeskId) {
 
     auto  vdesk = getOrCreateVdesk(vdeskId);
 
-    auto* window = g_pCompositor->getWindowByRegex(arg);
+    PHLWINDOW window = g_pCompositor->getWindowByRegex(arg);
     if (!window) {
         printLog(std::format("Window {} does not exist???", arg), LogLevel::ERR);
         return vdeskId;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,9 +14,9 @@
 #include <any>
 #include <vector>
 
-static HOOK_CALLBACK_FN*             onWorkspaceChangeHook = nullptr;
-static HOOK_CALLBACK_FN*             onWindowOpenHook      = nullptr;
-static HOOK_CALLBACK_FN*             onConfigReloadedHook  = nullptr;
+static std::shared_ptr<HOOK_CALLBACK_FN>             onWorkspaceChangeHook = nullptr;
+static std::shared_ptr<HOOK_CALLBACK_FN>             onWindowOpenHook      = nullptr;
+static std::shared_ptr<HOOK_CALLBACK_FN>             onConfigReloadedHook  = nullptr;
 
 inline CFunctionHook*                g_pMonitorConnectHook    = nullptr;
 inline CFunctionHook*                g_pMonitorDisconnectHook = nullptr;
@@ -229,7 +229,7 @@ void onWorkspaceChange(void*, SCallbackInfo&, std::any val) {
 }
 
 void onWindowOpen(void*, SCallbackInfo&, std::any val) {
-    CWindow* window = std::any_cast<CWindow*>(val);
+    PHLWINDOW window = std::any_cast<PHLWINDOW>(val);
     int      vdesk  = StickyApps::matchRuleOnWindow(stickyRules, manager, window);
     if (vdesk > 0)
         manager->changeActiveDesk(vdesk, true);

--- a/src/sticky_apps.cpp
+++ b/src/sticky_apps.cpp
@@ -29,7 +29,7 @@ bool StickyApps::parseWindowRule(const std::string& rule, SStickyRule& sticky) {
 
 void StickyApps::matchRules(const std::vector<SStickyRule>& rules, std::unique_ptr<VirtualDeskManager>& vdeskManager) {
     for (auto& r : rules) {
-        for (auto& w : g_pCompositor->m_vWindows) {
+        for (auto w : g_pCompositor->m_vWindows) {
             auto windowProp = extractProperty(r, w);
             if (windowProp == "")
                 continue;
@@ -45,7 +45,7 @@ void StickyApps::matchRules(const std::vector<SStickyRule>& rules, std::unique_p
     }
 }
 
-int StickyApps::matchRuleOnWindow(const std::vector<SStickyRule>& rules, std::unique_ptr<VirtualDeskManager>& vdeskManager, CWindow* window) {
+int StickyApps::matchRuleOnWindow(const std::vector<SStickyRule>& rules, std::unique_ptr<VirtualDeskManager>& vdeskManager, PHLWINDOW window) {
     for (auto& r : rules) {
         auto windowProp = extractProperty(r, window);
         if (windowProp == "")
@@ -63,20 +63,7 @@ int StickyApps::matchRuleOnWindow(const std::vector<SStickyRule>& rules, std::un
     return -1;
 }
 
-const std::string StickyApps::extractProperty(const SStickyRule& rule, std::unique_ptr<CWindow>& window) {
-    if (rule.property == TITLE) {
-        return g_pXWaylandManager->getTitle(window.get());
-    } else if (rule.property == INITIAL_TITLE) {
-        return window->m_szInitialTitle;
-    } else if (rule.property == CLASS) {
-        return g_pXWaylandManager->getAppIDClass(window.get());
-    } else if (rule.property == INITIAL_CLASS) {
-        return window->m_szInitialClass;
-    }
-    return "";
-}
-
-const std::string StickyApps::extractProperty(const SStickyRule& rule, CWindow* window) {
+const std::string StickyApps::extractProperty(const SStickyRule& rule, PHLWINDOW window) {
     if (rule.property == TITLE) {
         return g_pXWaylandManager->getTitle(window);
     } else if (rule.property == INITIAL_TITLE) {


### PR DESCRIPTION
I replaced some references of `CWindow` by `PHLWINDOW` which allows the plugin to be built for hyprland v0.39.1 again. The new build was tested on `v0.39.1-113` and it worked as expected. 

My c++ experience is very limited therefore let me know should something be off. 

On a side note:
For my rice I'd like to have some features for this plugin which are not yet implemented. I'm willing to implement them on my own but at the moment I have a very crappy c++ setup using vscode since Clion doesn't support projects using Makefiles. Would it be possible to maybe add a CMake or meson build configuration? This would make contributing a lot better since I'd be able to use Clion as my editor of choice