### PR TITLE
Update Hyprland URL to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Here is an example flake that you can modify to add hyprland-virtual-desktops to
     };
    
     hyprland = {
-      url = "github:hyprwm/Hyprland";
+      url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
       follows = "hyprland-virtual-desktops/hyprland"; # To make sure we run the same version of hyprland that the plugin was built against
     };
     hyprland-virtual-desktops.url = "github:levnikmyskin/hyprland-virtual-desktops";

--- a/flake.lock
+++ b/flake.lock
@@ -42,17 +42,19 @@
       },
       "locked": {
         "lastModified": 1714837352,
-        "narHash": "sha256-QzzJTb+0CBqgAT0wKZsOt1rky5+u2zMUlNxbZcGj2VM=",
-        "owner": "hyprwm",
-        "repo": "Hyprland",
+        "narHash": "sha256-UxpPPS5uiyE4FDO3trfJObOm6sE7jnkVguHH6IdkQqs=",
+        "ref": "refs/tags/v0.40.0",
         "rev": "cba1ade848feac44b2eda677503900639581c3f4",
-        "type": "github"
+        "revCount": 4606,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/hyprwm/Hyprland"
       },
       "original": {
-        "owner": "hyprwm",
-        "ref": "v0.40.0",
-        "repo": "Hyprland",
-        "type": "github"
+        "ref": "refs/tags/v0.40.0",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/hyprwm/Hyprland"
       }
     },
     "hyprland-protocols": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,13 @@
   description = "A plugin for the Hyprland compositor, implementing virtual-desktop functionality.";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  inputs.hyprland.url = "github:hyprwm/Hyprland/v0.40.0";
+  inputs.hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1&ref=refs/tags/v0.40.0";
 
   outputs = { self, nixpkgs, hyprland }:
     let
       # Helper function to create packages for each system
       withPkgsFor = fn: nixpkgs.lib.genAttrs (builtins.attrNames hyprland.packages) (system: fn system nixpkgs.legacyPackages.${system});
-      virtualDesktops = withPkgsFor (system: pkgs: pkgs.gcc13Stdenv.mkDerivation rec {
+      virtualDesktops = withPkgsFor (system: pkgs: pkgs.gcc13Stdenv.mkDerivation {
         pname = "virtual-desktops";
         version = "2.2.2";
         src = ./.;


### PR DESCRIPTION
https://github.com/hyprwm/Hyprland/pull/5667 was merged into Hyprland meaning the flake URL was changed from something like:

`inputs.hyprland.url = "github:hyprwm/Hyprland";`
to:
`inputs.hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";`

in our case that's from something like `"github:hyprwm/Hyprland/v0.40.0"` -> `"git+https://github.com/hyprwm/Hyprland?submodules=1&ref=refs/tags/v0.40.0"`.
While the commits 5677 introduced don't apply to v0.40.0, it still builds with this URL, so i thought it would be better to preemptively update it and not get a surprise breakage later. 
I also updated the README to reflect this change.

Haven't tested, but built and the $out path is different, but binary files are exactly the same, so shouldn't need testing, but it would be helpful since im not 100% sure about the inputs.hyprland.follows behavior, but it should be the same.
I also checked the flake.lock and the changes it made seem correct.