### PR TITLE
Printdesks command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ compile_flags.txt
 compile_commands.json
 .cache
 result/
+.idea

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Since version 2.2, this plugin exposes a couple of `hyprctl` commands. That is, 
 | Command | description | args | example|
 |------------|-------------|------|--------|
 | printdesk (vdesk)| Prints to Hyprland log the specified vdesk or the currently active vdesk* (if no argument is given) | optional vdesk, see [above](#hyprctl-dispatchers) | `hyprctl printdesk` or `hyprctl printdesk 2` or `hyprctl printdesk coding`|
-| printdesks | Prints information about all vdesks | `none` | `hyprctl printdesks` |
+| printstate | Prints state of all vdesks | `none` | `hyprctl printstate` |
 | printlayout | print to Hyprland logs the current layout | `none` | `hyprctl printlayout` |
 
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Since version 2.2, this plugin exposes a couple of `hyprctl` commands. That is, 
 | Command | description | args | example|
 |------------|-------------|------|--------|
 | printdesk (vdesk)| Prints to Hyprland log the specified vdesk or the currently active vdesk* (if no argument is given) | optional vdesk, see [above](#hyprctl-dispatchers) | `hyprctl printdesk` or `hyprctl printdesk 2` or `hyprctl printdesk coding`|
+| printdesks | Prints information about all vdesks | `none` | `hyprctl printdesks` |
 | printlayout | print to Hyprland logs the current layout | `none` | `hyprctl printlayout` |
 
 

--- a/include/VirtualDesk.hpp
+++ b/include/VirtualDesk.hpp
@@ -14,6 +14,7 @@
 #include <hyprland/src/helpers/memory/SharedPtr.hpp>
 
 typedef std::unordered_map<int, int>             WorkspaceMap;
+// map with CMonitor* -> hyprland workspace id
 typedef std::unordered_map<const CMonitor*, int> Layout;
 typedef std::string                              MonitorName;
 

--- a/include/VirtualDeskManager.hpp
+++ b/include/VirtualDeskManager.hpp
@@ -10,7 +10,6 @@ class VirtualDeskManager {
   public:
     VirtualDeskManager();
     std::unordered_map<int, std::shared_ptr<VirtualDesk>> vdesksMap;
-    std::unordered_map<int, std::vector<PHLWINDOW>>       vdeskWindowsMap;
     int                                                   lastDesk      = -1;
     std::unordered_map<int, std::string>                  vdeskNamesMap = {{1, "1"}};
     RememberLayoutConf                                    conf;
@@ -31,9 +30,6 @@ class VirtualDeskManager {
     int                                                   prevDeskId(bool backwardCycle);
     int                                                   nextDeskId(bool cycle);
     int                                                   getDeskIdFromName(const std::string& name, bool createIfNotFound = true);
-    int                                                   getDeskIdForWorkspace(int workspaceId);
-    void                                                  moveWindowToDesk(PHLWINDOW window, int vdeskId);
-    void                                                  removeWindow(PHLWINDOW window);
 
   private:
     int                          m_activeDeskKey = 1;

--- a/include/VirtualDeskManager.hpp
+++ b/include/VirtualDeskManager.hpp
@@ -10,6 +10,7 @@ class VirtualDeskManager {
   public:
     VirtualDeskManager();
     std::unordered_map<int, std::shared_ptr<VirtualDesk>> vdesksMap;
+    std::unordered_map<int, std::vector<PHLWINDOW>>       vdeskWindowsMap;
     int                                                   lastDesk      = -1;
     std::unordered_map<int, std::string>                  vdeskNamesMap = {{1, "1"}};
     RememberLayoutConf                                    conf;
@@ -30,6 +31,9 @@ class VirtualDeskManager {
     int                                                   prevDeskId(bool backwardCycle);
     int                                                   nextDeskId(bool cycle);
     int                                                   getDeskIdFromName(const std::string& name, bool createIfNotFound = true);
+    int                                                   getDeskIdForWorkspace(int workspaceId);
+    void                                                  moveWindowToDesk(PHLWINDOW window, int vdeskId);
+    void                                                  removeWindow(PHLWINDOW window);
 
   private:
     int                          m_activeDeskKey = 1;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -37,7 +37,7 @@ const std::string BACKCYCLE_DISPATCH_STR  = "backcyclevdesks";
 
 const std::string RESET_VDESK_DISPATCH_STR = "vdeskreset";
 const std::string PRINTDESK_DISPATCH_STR   = "printdesk";
-const std::string PRINTDESKS_DISPATCH_STR  = "printdesks";
+const std::string PRINTSTATE_DISPATCH_STR  = "printstate";
 const std::string PRINTLAYOUT_DISPATCH_STR = "printlayout";
 
 const std::string REMEMBER_NONE     = "none";

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -37,6 +37,7 @@ const std::string BACKCYCLE_DISPATCH_STR  = "backcyclevdesks";
 
 const std::string RESET_VDESK_DISPATCH_STR = "vdeskreset";
 const std::string PRINTDESK_DISPATCH_STR   = "printdesk";
+const std::string PRINTDESKS_DISPATCH_STR  = "printdesks";
 const std::string PRINTLAYOUT_DISPATCH_STR = "printlayout";
 
 const std::string REMEMBER_NONE     = "none";

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -161,6 +161,17 @@ int VirtualDeskManager::getDeskIdFromName(const std::string& name, bool createIf
     return vdesk;
 }
 
+int VirtualDeskManager::getDeskIdForWorkspace(int workspaceId) {
+    for (auto const& [vdeskId, vdesk] : vdesksMap) {
+        for(auto const& layout : vdesk->layouts) {
+            for(auto const& [mon, workspace] : layout) {
+                if (workspace == workspaceId) return vdeskId;
+            }
+        }
+    }
+    return -1;
+}
+
 void VirtualDeskManager::loadLayoutConf() {
     // Having the possibility to change this at any given time
     // poses just too many issues to think about for now.
@@ -292,4 +303,22 @@ CMonitor* VirtualDeskManager::getCurrentMonitor() {
         return nullptr;
     }
     return currentMonitor;
+}
+void VirtualDeskManager::moveWindowToDesk(const PHLWINDOW window, int newVdeskId) {
+    // delete window from another vdesk should it be associated to any other
+    removeWindow(window);
+
+    auto val = &vdeskWindowsMap[newVdeskId];
+    if (!val) vdeskWindowsMap[newVdeskId] = std::vector<PHLWINDOW>(1, window);
+    else val->push_back(window);
+}
+
+void VirtualDeskManager::removeWindow(PHLWINDOW window) {
+    for(auto& [vdeskId, windows] : vdeskWindowsMap) {
+        auto it = std::find(windows.begin(), windows.end(), window);
+        if (it != windows.end()) {
+            windows.erase(it);
+            return;
+        }
+    }
 }

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -189,7 +189,7 @@ void VirtualDeskManager::cycleWorkspaces() {
         return;
 
     auto      n_monitors     = g_pCompositor->m_vMonitors.size();
-    CMonitor* currentMonitor = g_pCompositor->m_pLastMonitor;
+    CMonitor* currentMonitor = g_pCompositor->m_pLastMonitor.get();
 
     // TODO: implement for more than two monitors as well.
     // This probably requires to compute monitors position
@@ -292,7 +292,7 @@ void VirtualDeskManager::invalidateAllLayouts() {
 }
 
 CMonitor* VirtualDeskManager::getCurrentMonitor() {
-    CMonitor* currentMonitor = g_pCompositor->m_pLastMonitor;
+    CMonitor* currentMonitor = g_pCompositor->m_pLastMonitor.get();
     // This can happen when we receive the "on disconnect" signal
     // let's just take first monitor we can find
     if (currentMonitor && (!currentMonitor->m_bEnabled || !currentMonitor->output)) {

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -161,17 +161,6 @@ int VirtualDeskManager::getDeskIdFromName(const std::string& name, bool createIf
     return vdesk;
 }
 
-int VirtualDeskManager::getDeskIdForWorkspace(int workspaceId) {
-    for (auto const& [vdeskId, vdesk] : vdesksMap) {
-        for(auto const& layout : vdesk->layouts) {
-            for(auto const& [mon, workspace] : layout) {
-                if (workspace == workspaceId) return vdeskId;
-            }
-        }
-    }
-    return -1;
-}
-
 void VirtualDeskManager::loadLayoutConf() {
     // Having the possibility to change this at any given time
     // poses just too many issues to think about for now.
@@ -303,22 +292,4 @@ CMonitor* VirtualDeskManager::getCurrentMonitor() {
         return nullptr;
     }
     return currentMonitor;
-}
-void VirtualDeskManager::moveWindowToDesk(const PHLWINDOW window, int newVdeskId) {
-    // delete window from another vdesk should it be associated to any other
-    removeWindow(window);
-
-    auto val = &vdeskWindowsMap[newVdeskId];
-    if (!val) vdeskWindowsMap[newVdeskId] = std::vector<PHLWINDOW>(1, window);
-    else val->push_back(window);
-}
-
-void VirtualDeskManager::removeWindow(PHLWINDOW window) {
-    for(auto& [vdeskId, windows] : vdeskWindowsMap) {
-        auto it = std::find(windows.begin(), windows.end(), window);
-        if (it != windows.end()) {
-            windows.erase(it);
-            return;
-        }
-    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,7 +174,7 @@ std::string printVDeskDispatch(eHyprCtlOutputFormat format, std::string arg) {
     return "";
 }
 
-std::string printVDesksDispatch(eHyprCtlOutputFormat format, std::string arg) {
+std::string printStateDispatch(eHyprCtlOutputFormat format, std::string arg) {
     std::string out;
     if (format == eHyprCtlOutputFormat::FORMAT_NORMAL) {
         out += "Virtual desks\n";
@@ -183,13 +183,11 @@ std::string printVDesksDispatch(eHyprCtlOutputFormat format, std::string arg) {
             unsigned int windows = 0;
             std::string workspaces;
             bool first = true;
-            for(auto const& layout : desk->layouts) {
-                for(auto const& [monitor, workspaceId] : layout) {
-                    windows += g_pCompositor->getWindowsOnWorkspace(workspaceId);
-                    if(!first) workspaces += ", ";
-                    else first = false;
-                    workspaces += std::format("{}", workspaceId);
-                }
+            for(auto const& [monitor, workspaceId] : desk->activeLayout(manager->conf)) {
+                windows += g_pCompositor->getWindowsOnWorkspace(workspaceId);
+                if(!first) workspaces += ", ";
+                else first = false;
+                workspaces += std::format("{}", workspaceId);
             }
             out += std::format(
                 "- {}: {}\n  Focused: {}\n  Populated: {}\n  Workspaces: {}\n  Windows: {}\n",
@@ -209,13 +207,11 @@ std::string printVDesksDispatch(eHyprCtlOutputFormat format, std::string arg) {
             unsigned int windows = 0;
             std::string workspaces;
             bool first = true;
-            for(auto const& layout : desk->layouts) {
-                for(auto const& [monitor, workspaceId] : layout) {
-                    windows += g_pCompositor->getWindowsOnWorkspace(workspaceId);
-                    if(!first) workspaces += ", ";
-                    else first = false;
-                    workspaces += std::format("{}", workspaceId);
-                }
+            for(auto const& [monitor, workspaceId] : desk->activeLayout(manager->conf)) {
+                windows += g_pCompositor->getWindowsOnWorkspace(workspaceId);
+                if(!first) workspaces += ", ";
+                else first = false;
+                workspaces += std::format("{}", workspaceId);
             }
             vdesks += std::format(R"#({{
                 "id": {},
@@ -348,13 +344,13 @@ void registerHyprctlCommands() {
     if (!ptr)
         printLog(std::format("Failed to register hyprctl command: {}", PRINTLAYOUT_DISPATCH_STR));
 
-    // Register printdesks
-    cmd.name  = PRINTDESKS_DISPATCH_STR;
-    cmd.fn    = printVDesksDispatch;
+    // Register printstate
+    cmd.name  = PRINTSTATE_DISPATCH_STR;
+    cmd.fn    = printStateDispatch;
     cmd.exact = true;
     ptr       = HyprlandAPI::registerHyprCtlCommand(PHANDLE, cmd);
     if (!ptr)
-        printLog(std::format("Failed to register hyprctl command: {}", PRINTDESKS_DISPATCH_STR));
+        printLog(std::format("Failed to register hyprctl command: {}", PRINTSTATE_DISPATCH_STR));
 
     // Register printdesk
     cmd.name  = PRINTDESK_DISPATCH_STR;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,21 +179,30 @@ std::string printVDeskDispatch(eHyprCtlOutputFormat format, std::string arg) {
 std::string printVDesksDispatch(eHyprCtlOutputFormat format, std::string arg) {
     std::string out;
     if (format == eHyprCtlOutputFormat::FORMAT_NORMAL) {
-        // TODO: Finish this print statement
-        out += std::format(R"#(Virtual desks
-        )#");
+        out += "Virtual desks\n";
+        int index = 0;
+        for(auto const& [vdeskId, desk] : manager->vdesksMap) {
+            auto windows = manager->vdeskWindowsMap[vdeskId];
+            out += std::format(
+                "- {}: {}\n  Windows: {}\n  Focused: {}\n",
+                desk->name,
+                desk->id,
+                windows.size(),
+                manager->activeVdesk().get() == desk.get()
+            );
+            if(index++ < manager->vdesksMap.size() - 1) out += "\n";
+        }
     } else if(format == eHyprCtlOutputFormat::FORMAT_JSON) {
         std::string vdesks;
         int index = 0;
         for(auto const& [vdeskId, desk] : manager->vdesksMap) {
             auto windows = manager->vdeskWindowsMap[vdeskId];
-            printLog(std::format("Windows: {}, desk: {}", windows.size(), vdeskId));
             vdesks += std::format(R"#({{
                 "id": {},
                 "name": "{}",
-                "active": {},
+                "focused": {},
                 "populated": {}
-            }})#", vdeskId, manager->activeVdesk().get() == desk.get(), windows.size() > 0, desk->name);
+            }})#", vdeskId, desk->name, manager->activeVdesk().get() == desk.get(), !windows.empty());
             if(index++ < manager->vdesksMap.size() - 1) vdesks += ",";
         }
         out += std::format(R"#([{}])#", vdesks);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,8 @@
 
 static CSharedPointer<HOOK_CALLBACK_FN> onWorkspaceChangeHook = nullptr;
 static CSharedPointer<HOOK_CALLBACK_FN> onWindowOpenHook      = nullptr;
+static CSharedPointer<HOOK_CALLBACK_FN> onWindowCloseHook     = nullptr;
+static CSharedPointer<HOOK_CALLBACK_FN> onWindowMoveHook      = nullptr;
 static CSharedPointer<HOOK_CALLBACK_FN> onConfigReloadedHook  = nullptr;
 
 inline CFunctionHook*                   g_pMonitorConnectHook    = nullptr;
@@ -174,6 +176,31 @@ std::string printVDeskDispatch(eHyprCtlOutputFormat format, std::string arg) {
     return "";
 }
 
+std::string printVDesksDispatch(eHyprCtlOutputFormat format, std::string arg) {
+    std::string out;
+    if (format == eHyprCtlOutputFormat::FORMAT_NORMAL) {
+        // TODO: Finish this print statement
+        out += std::format(R"#(Virtual desks
+        )#");
+    } else if(format == eHyprCtlOutputFormat::FORMAT_JSON) {
+        std::string vdesks;
+        int index = 0;
+        for(auto const& [vdeskId, desk] : manager->vdesksMap) {
+            auto windows = manager->vdeskWindowsMap[vdeskId];
+            printLog(std::format("Windows: {}, desk: {}", windows.size(), vdeskId));
+            vdesks += std::format(R"#({{
+                "id": {},
+                "name": "{}",
+                "active": {},
+                "populated": {}
+            }})#", vdeskId, manager->activeVdesk().get() == desk.get(), windows.size() > 0, desk->name);
+            if(index++ < manager->vdesksMap.size() - 1) vdesks += ",";
+        }
+        out += std::format(R"#([{}])#", vdesks);
+    }
+    return out;
+}
+
 std::string printLayoutDispatch(eHyprCtlOutputFormat format, std::string arg) {
     auto        activeDesk = manager->activeVdesk();
     auto        layout     = activeDesk->activeLayout(manager->conf);
@@ -234,6 +261,26 @@ void onWindowOpen(void*, SCallbackInfo&, std::any val) {
     int       vdesk  = StickyApps::matchRuleOnWindow(stickyRules, manager, window);
     if (vdesk > 0)
         manager->changeActiveDesk(vdesk, true);
+
+    vdesk = manager->getDeskIdForWorkspace(window->workspaceID());
+    if (isVerbose())
+        printLog(std::format("Adding new window to vdesk {}", vdesk));
+    manager->moveWindowToDesk(window, vdesk);
+
+}
+
+void onWindowClose(void*, SCallbackInfo&, std::any val) {
+    PHLWINDOW window = std::any_cast<PHLWINDOW>(val);
+    manager->removeWindow(window);
+}
+
+void onWindowMove(void*, SCallbackInfo&, std::any val) {
+    auto args = std::any_cast<std::vector<std::any>>(val);
+    auto window = std::any_cast<PHLWINDOW>(args.at(0));
+    int vdesk = manager->getDeskIdForWorkspace(window->workspaceID());
+    if (isVerbose())
+        printLog(std::format("Moving window to vdesk {}", vdesk));
+    manager->moveWindowToDesk(window, vdesk);
 }
 
 void hookMonitorDisconnect(void* thisptr, bool destroy) {
@@ -290,13 +337,21 @@ void registerHyprctlCommands() {
     if (!ptr)
         printLog(std::format("Failed to register hyprctl command: {}", PRINTLAYOUT_DISPATCH_STR));
 
+    // Register printdesks
+    cmd.name  = PRINTDESKS_DISPATCH_STR;
+    cmd.fn    = printVDesksDispatch;
+    cmd.exact = true;
+    ptr       = HyprlandAPI::registerHyprCtlCommand(PHANDLE, cmd);
+    if (!ptr)
+        printLog(std::format("Failed to register hyprctl command: {}", PRINTDESKS_DISPATCH_STR));
+
     // Register printdesk
     cmd.name  = PRINTDESK_DISPATCH_STR;
     cmd.fn    = printVDeskDispatch;
     cmd.exact = false;
     ptr       = HyprlandAPI::registerHyprCtlCommand(PHANDLE, cmd);
     if (!ptr)
-        printLog(std::format("Failed to register hyprctl command: {}", VDESK_DISPATCH_STR));
+        printLog(std::format("Failed to register hyprctl command: {}", PRINTDESK_DISPATCH_STR));
 }
 
 // Do NOT change this function.
@@ -338,6 +393,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     onWorkspaceChangeHook = HyprlandAPI::registerCallbackDynamic(PHANDLE, "workspace", onWorkspaceChange);
     onWindowOpenHook      = HyprlandAPI::registerCallbackDynamic(PHANDLE, "openWindow", onWindowOpen);
+    onWindowCloseHook     = HyprlandAPI::registerCallbackDynamic(PHANDLE, "closeWindow", onWindowClose);
+    onWindowMoveHook      = HyprlandAPI::registerCallbackDynamic(PHANDLE, "moveWindow", onWindowMove);
     onConfigReloadedHook  = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", onConfigReloaded);
 
     // Function hooks


### PR DESCRIPTION
Hi

I've added the `hyprctl printdesks` command which outputs information about all vdesks currently available

The output below is an example of running `hyprctl printdesks -j` which can be easily processed by other applications (e.g. sidebar widgets):
```typescript
[
  {
    "id": 4,
    "name": "4",
    "focused": false,
    "populated": false
  },
  {
    "id": 3,
    "name": "3",
    "focused": false,
    "populated": false
  },
  {
    "id": 2,
    "name": "2",
    "focused": false,
    "populated": true
  },
  {
    "id": 1,
    "name": "1",
    "focused": true,
    "populated": true
  }
]
```

Now, the plugin stores a list with all open windows for every vdesk which has to be updated when a window opens, closes or gets moved to another workspace (which potentially is part of another vdesk). Therefore, it was necessary to add some event listeners. 

The branch is rebased onto `dev` and therefore the new feature will be available for all users as soon as the next hyprland version is released. 