### PR TITLE
Fix sticky apps extract property

### DIFF
--- a/src/sticky_apps.cpp
+++ b/src/sticky_apps.cpp
@@ -65,11 +65,11 @@ int StickyApps::matchRuleOnWindow(const std::vector<SStickyRule>& rules, std::un
 
 const std::string StickyApps::extractProperty(const SStickyRule& rule, PHLWINDOW window) {
     if (rule.property == TITLE) {
-        return g_pXWaylandManager->getTitle(window);
+        return window->m_szTitle;
     } else if (rule.property == INITIAL_TITLE) {
         return window->m_szInitialTitle;
     } else if (rule.property == CLASS) {
-        return g_pXWaylandManager->getAppIDClass(window);
+        return window->m_szClass;
     } else if (rule.property == INITIAL_CLASS) {
         return window->m_szInitialClass;
     }


### PR DESCRIPTION
The latest version of hyprland-git (https://github.com/hyprwm/Hyprland/commit/0cfdde3d1acbfbf698af17f6986fbc4d644214da) replaced the `getTitle` and `getAppIDClass` methods from the `g_pXWaylandManager` by the `m_szTitle` and `m_szClass` property on the `PHLWINDOW`

**Note**: I saw you added a policy to the `dev` branch which requires me to create a pull request for small fixes like this one - was this your intention or is this a unwanted sideeffect? In my opinion it's sufficient to only have a branch policy on the `main` branch