### PR TITLE
fix printlayout json output invaild

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,12 +189,15 @@ std::string printLayoutDispatch(eHyprCtlOutputFormat format, std::string arg) {
             "monitors": [
                 )#",
                            activeDesk->name, layout.size());
+        int index = 0;
         for (auto const& [mon, wid] : layout) {
             out += std::format(R"#({{
                 "monitorId": {},
                 "workspace": {}
             }})#",
                                mon->ID, wid);
+            if (++index < layout.size())
+                out += ",";
         }
         out += "]\n}";
     }


### PR DESCRIPTION
> Hyprland, built from branch  at commit cba1ade848feac44b2eda677503900639581c3f4  (props: bump version to 0.40.0).
Date: Sat May 4 15:42:32 2024
Tag: v0.40.0, commits: 4606


* Fix `printlayout` output json invaild syntax
* ~Change makefile run shell command via `shell` function (GNU make)~

