### PR TITLE
fix: work on aquamarine backend

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -49,6 +49,7 @@ runs:
           libxfont2 \
           libxkbcommon \
           libxkbfile \
+          libxcursor \
           lld \
           meson \
           ninja \
@@ -85,6 +86,15 @@ runs:
       run: |
         git clone https://github.com/hyprwm/hyprutils.git
         cd hyprutils
+        cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -S . -B ./build
+        cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf _NPROCESSORS_CONF`
+        cmake --install build
+
+    - name: Get aquamarine
+      shell: bash
+      run: |
+        git clone https://github.com/hyprwm/aquamarine.git
+        cd aquamarine
         cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -S . -B ./build
         cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf _NPROCESSORS_CONF`
         cmake --install build

--- a/src/VirtualDesk.cpp
+++ b/src/VirtualDesk.cpp
@@ -184,5 +184,5 @@ Layout VirtualDesk::generateCurrentMonitorLayout() {
 std::string VirtualDesk::monitorDesc(const CMonitor* monitor) {
     if (!monitor->output)
         return monitor->szName;
-    return monitor->output->description;
+    return monitor->szDescription.empty() ? monitor->szName : monitor->szDescription;
 }

--- a/src/VirtualDesk.cpp
+++ b/src/VirtualDesk.cpp
@@ -184,5 +184,5 @@ Layout VirtualDesk::generateCurrentMonitorLayout() {
 std::string VirtualDesk::monitorDesc(const CMonitor* monitor) {
     if (!monitor->output)
         return monitor->szName;
-    return monitor->output->description ? monitor->output->description : monitor->szName;
+    return monitor->output->description;
 }


### PR DESCRIPTION
The new `aquamarine` backend no longer uses an char pointer array but the string from the standard library which cannot be a nullptr