### PR TITLE
Fix monitor smart pointers

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -57,7 +57,7 @@ void                                  printLog(std::string s, LogLevel level = I
 
 std::string                           parseMoveDispatch(std::string& arg);
 bool                                  extractBool(std::string& arg);
-std::vector<CSharedPointer<CMonitor>> currentlyEnabledMonitors(const CSharedPointer<CMonitor> exclude = nullptr);
+std::vector<CSharedPointer<CMonitor>> currentlyEnabledMonitors(const CSharedPointer<CMonitor>& exclude = nullptr);
 
 std::string                           ltrim(const std::string& s);
 std::string                           rtrim(const std::string& s);


### PR DESCRIPTION
Hi, 

I just noticed a reference was missing in the header of `utils.hpp`

Somehow it worked on my debug build on my desktop but now when I install the plugin on my laptop it causes Hyprland to crash with a missing symbol error.