### PR TITLE
Fix workspace monitors

### DIFF
--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -77,7 +77,7 @@ void VirtualDeskManager::applyCurrentVDesk() {
             workspace = g_pCompositor->createNewWorkspace(workspaceId, mon->ID);
         }
 
-        if (workspace->m_iMonitorID != mon->ID)
+        if (workspace->m_pMonitor != mon)
             g_pCompositor->moveWorkspaceToMonitor(workspace, currentMonitor);
 
         // Hack: we change the workspace on the current monitor as our last operation,
@@ -125,7 +125,7 @@ int VirtualDeskManager::moveToDesk(std::string& arg, int vdeskId) {
     // of the window
     auto wid = vdesk->activeLayout(conf).begin()->second;
     for (auto const& [mon, workspace] : vdesk->activeLayout(conf)) {
-        if (mon->ID == window->m_iMonitorID) {
+        if (mon == window->m_pMonitor) {
             wid = workspace;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,13 +278,13 @@ void onWorkspaceChange(void*, SCallbackInfo&, std::any val) {
     auto workspace   = std::any_cast<PHLWORKSPACE>(val);
     WORKSPACEID         workspaceID = std::any_cast<PHLWORKSPACE>(val)->m_iID;
 
-    auto         monitor = g_pCompositor->getMonitorFromID(workspace->m_iMonitorID);
+    auto monitor = workspace->m_pMonitor.lock();
     if (!monitor || !monitor->m_bEnabled)
         return;
 
     manager->activeVdesk()->changeWorkspaceOnMonitor(workspaceID, monitor);
     if (isVerbose())
-        printLog("workspace changed: workspace id " + std::to_string(workspaceID) + "; on monitor " + std::to_string(workspace->m_iMonitorID));
+        printLog("workspace changed: workspace id " + std::to_string(workspaceID) + "; on monitor " + std::to_string(monitor->ID));
 }
 
 void onWindowOpen(void*, SCallbackInfo&, std::any val) {


### PR DESCRIPTION
Hi,

On the latest git version the `m_iMonitorID` field was removed from the workspace and replaced with a shared pointer to the monitor `m_pMonitor`

I replaced all usages of the `m_iMonitorID` with a equivalent statement using `m_pMonitor`
