### PR TITLE
Listen to new pre/post monitor connection/disconnection events

### DIFF
--- a/include/VirtualDeskManager.hpp
+++ b/include/VirtualDeskManager.hpp
@@ -30,12 +30,12 @@ class VirtualDeskManager {
     int                                                   prevDeskId(bool backwardCycle);
     int                                                   nextDeskId(bool cycle);
     int                                                   getDeskIdFromName(const std::string& name, bool createIfNotFound = true);
-    CSharedPointer<CMonitor>                              getFocusedMonitor();
 
   private:
     int                          m_activeDeskKey = 1;
     bool                         confLoaded      = false;
     void                         cycleWorkspaces();
     std::shared_ptr<VirtualDesk> getOrCreateVdesk(int vdeskId);
+    CSharedPointer<CMonitor>                              getFocusedMonitor();
 };
 #endif

--- a/include/VirtualDeskManager.hpp
+++ b/include/VirtualDeskManager.hpp
@@ -30,12 +30,12 @@ class VirtualDeskManager {
     int                                                   prevDeskId(bool backwardCycle);
     int                                                   nextDeskId(bool cycle);
     int                                                   getDeskIdFromName(const std::string& name, bool createIfNotFound = true);
+    CSharedPointer<CMonitor>                              getFocusedMonitor();
 
   private:
     int                          m_activeDeskKey = 1;
     bool                         confLoaded      = false;
     void                         cycleWorkspaces();
-    CSharedPointer<CMonitor>     getCurrentMonitor();
     std::shared_ptr<VirtualDesk> getOrCreateVdesk(int vdeskId);
 };
 #endif

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -57,7 +57,7 @@ void VirtualDeskManager::applyCurrentVDesk() {
     }
     if (isVerbose())
         printLog("applying vdesk" + activeVdesk()->name);
-    auto         currentMonitor   = getCurrentMonitor();
+    auto         currentMonitor   = getFocusedMonitor();
     auto         layout           = activeVdesk()->activeLayout(conf);
     PHLWORKSPACE focusedWorkspace = nullptr;
     for (const auto& [lmon, workspaceId] : layout) {
@@ -177,7 +177,7 @@ void VirtualDeskManager::cycleWorkspaces() {
     if (!**PCYCLEWORKSPACES)
         return;
 
-    auto      n_monitors     = g_pCompositor->m_vMonitors.size();
+    auto                     n_monitors     = g_pCompositor->m_vMonitors.size();
     CSharedPointer<CMonitor> currentMonitor = g_pCompositor->m_pLastMonitor.lock();
 
     // TODO: implement for more than two monitors as well.
@@ -280,7 +280,7 @@ void VirtualDeskManager::invalidateAllLayouts() {
     }
 }
 
-CSharedPointer<CMonitor> VirtualDeskManager::getCurrentMonitor() {
+CSharedPointer<CMonitor> VirtualDeskManager::getFocusedMonitor() {
     CWeakPointer<CMonitor> currentMonitor = g_pCompositor->m_pLastMonitor;
     // This can happen when we receive the "on disconnect" signal
     // let's just take first monitor we can find


### PR DESCRIPTION
This finally removes the need to have the function hooks for monitor connection/disconnection. This is already merged into Hyprland https://github.com/hyprwm/Hyprland/pull/8503

This should remove a good set of issues