### PR TITLE
fix: apply upstream LogLevel renaming

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -53,7 +53,7 @@ enum RememberLayoutConf {
 
 RememberLayoutConf                    layoutConfFromInt(const int64_t);
 RememberLayoutConf                    layoutConfFromString(const std::string& conf);
-void                                  printLog(std::string s, LogLevel level = INFO);
+void                                  printLog(std::string s, eLogLevel level = INFO);
 
 std::string                           parseMoveDispatch(std::string& arg);
 bool                                  extractBool(std::string& arg);

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -116,7 +116,7 @@ int VirtualDeskManager::moveToDesk(std::string& arg, int vdeskId) {
 
     PHLWINDOW window = g_pCompositor->getWindowByRegex(arg);
     if (!window) {
-        printLog(std::format("Window {} does not exist???", arg), LogLevel::ERR);
+        printLog(std::format("Window {} does not exist???", arg), eLogLevel::ERR);
         return vdeskId;
     }
 
@@ -230,12 +230,12 @@ void VirtualDeskManager::resetVdesk(const std::string& arg) {
     } catch (std::exception const& ex) { vdeskId = getDeskIdFromName(arg, false); }
 
     if (vdeskId == -1) {
-        printLog("Reset vdesk: " + arg + " not found", LogLevel::WARN);
+        printLog("Reset vdesk: " + arg + " not found", eLogLevel::WARN);
         return;
     }
 
     if (!vdesksMap.contains(vdeskId)) {
-        printLog("Reset vdesk: " + arg + " not found in map. This should not happen :O", LogLevel::ERR);
+        printLog("Reset vdesk: " + arg + " not found in map. This should not happen :O", eLogLevel::ERR);
         return;
     }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,6 @@
 #include "utils.hpp"
 
-void printLog(std::string s, LogLevel level) {
+void printLog(std::string s, eLogLevel level) {
     // #ifdef DEBUG
     //     std::cout << "[virtual-desktops] " + s << std::endl;
     // #endif


### PR DESCRIPTION
Upsteam changes the naming LogLevel to eLogLevel in 
https://github.com/hyprwm/Hyprland/commit/8bbeee11734d3ba8e2cf15d19cb3c302f8bfdbf2

We should change it correspondingly.