### PR TITLE
Include regex in sticky apps

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -72,7 +72,8 @@ runs:
           librsvg \
           libwebp \
           libjxl \
-          libjpeg-turbo
+          libjpeg-turbo \
+          re2
 
     - name: Get hyprwayland-scanner-git
       shell: bash

--- a/src/sticky_apps.cpp
+++ b/src/sticky_apps.cpp
@@ -1,5 +1,6 @@
 #include "sticky_apps.hpp"
 #include "utils.hpp"
+#include <regex>
 
 bool StickyApps::parseRule(const std::string& rule, SStickyRule& sticky, std::unique_ptr<VirtualDeskManager>& vdeskManager) {
     auto comma_pos = rule.find(',');


### PR DESCRIPTION
Hi,

It seems hyprland no longer includes `<regex>` and therefore the plugin no longer builds as the sticky apps depend on `std::regex`. 

I've now included the `<regex>` library directly in the `sticky_apps.cpp` file