### PR TITLE
Fix `movtodesk` dispatchers

### DIFF
--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -1,4 +1,5 @@
 #include "VirtualDeskManager.hpp"
+#include "src/desktop/DesktopTypes.hpp"
 #include <hyprland/src/Compositor.hpp>
 #include <format>
 #include <ranges>
@@ -114,10 +115,17 @@ int VirtualDeskManager::moveToDesk(std::string& arg, int vdeskId) {
 
     auto      vdesk = getOrCreateVdesk(vdeskId);
 
-    PHLWINDOW window = g_pCompositor->getWindowByRegex(arg);
-    if (!window) {
-        printLog(std::format("Window {} does not exist???", arg), eLogLevel::ERR);
-        return vdeskId;
+    // monitor of the target window
+    // if no arg is provided, it's the currently focussed monitor and otherwise
+    // it's the monitor of the window matched by the arg regex
+    PHLMONITORREF monitor = g_pCompositor->m_pLastMonitor;
+    if (arg != "") {
+        PHLWINDOW window = g_pCompositor->getWindowByRegex(arg);
+        if (!window) {
+            printLog(std::format("Window {} does not exist???", arg), eLogLevel::ERR);
+            return vdeskId;
+        }
+        monitor = window->m_pMonitor;
     }
 
     // take the first workspace wherever in the layout
@@ -125,7 +133,7 @@ int VirtualDeskManager::moveToDesk(std::string& arg, int vdeskId) {
     // of the window
     auto wid = vdesk->activeLayout(conf).begin()->second;
     for (auto const& [mon, workspace] : vdesk->activeLayout(conf)) {
-        if (mon == window->m_pMonitor) {
+        if (mon == monitor) {
             wid = workspace;
         }
     }

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -1,5 +1,4 @@
 #include "VirtualDeskManager.hpp"
-#include "src/desktop/DesktopTypes.hpp"
 #include <hyprland/src/Compositor.hpp>
 #include <format>
 #include <ranges>
@@ -123,9 +122,9 @@ int VirtualDeskManager::moveToDesk(std::string& arg, int vdeskId) {
         PHLWINDOW window = g_pCompositor->getWindowByRegex(arg);
         if (!window) {
             printLog(std::format("Window {} does not exist???", arg), eLogLevel::ERR);
-            return vdeskId;
+        } else {
+            monitor = window->m_pMonitor;
         }
-        monitor = window->m_pMonitor;
     }
 
     // take the first workspace wherever in the layout


### PR DESCRIPTION
Hi,

Since the switch from `std::regex` to `re2` as a regex library for hyprland (https://github.com/hyprwm/Hyprland/commit/e06b520427a30f1c86562ad7cc3794bf03b40188) the `movetodesk` dispatcher(s) are kind of broken.

For example with the config: 
```ini
plugin {
    virtual-desktops {
        cycleworkspaces = 0
        notifyinit = 0
        names = 1:1, 2:2, 3:3, 4:4, 5:5
    }
}
```

I previously was able to switch vdesks using `dispatch movetodesk <id>` where `<id>` is either `1`, `2`, `3`, `4` or `5`. 

When I dispatch `movetodesk 2` without further arguments we have `arg = ''` in the `VirtualDeskManager::moveToDesk` method. 

https://github.com/levnikmyskin/hyprland-virtual-desktops/blob/45001c5f826f80b6a504b7e37253147c4080c20a/src/VirtualDeskManager.cpp#L117-L121

We then call `getWindowByRegex(arg)` which now returns no window (probably due to us passing an empty string and `re2` not liking this in comparison to `std::regex` which most likely just returned the current window). This causes the assertion and therefore every move to fail.

I've now wrapped the whole assertion into a check whether `arg` is non-empty. Since we only use the `window` from `getWindowByRegex` to determine the target monitor we set `monitor` to the current monitor by default. Should `arg` be non-empty we try to get a window matching the `arg` and set `monitor` to the monitor of the matched window. If no window matches we currently just return and don't move anything. I think it would be better when we log some error and then move to the default `monitor` (which is the current monitor) as it's probably more like the functionality which was tried to be achieved by the user.

I'm not entirely sure whether this could break some control flows as I don't have  this deep of an understanding of the functionalities of the plugin which I only rarely use