### PR TITLE
Include empty named vdesks in state

### DIFF
--- a/src/VirtualDesk.cpp
+++ b/src/VirtualDesk.cpp
@@ -103,15 +103,15 @@ CSharedPointer<CMonitor> VirtualDesk::deleteInvalidMonitor(const CSharedPointer<
 }
 
 void VirtualDesk::deleteInvalidMonitorsOnActiveLayout() {
-    Layout                              layout_copy(layouts[m_activeLayout_idx]);
-    auto                                enabledMonitors = currentlyEnabledMonitors();
-    std::unordered_set<CSharedPointer<CMonitor>>    enabledMonitors_set;
+    Layout                                       layout_copy(layouts[m_activeLayout_idx]);
+    auto                                         enabledMonitors = currentlyEnabledMonitors();
+    std::unordered_set<CSharedPointer<CMonitor>> enabledMonitors_set;
     for (const auto& mon : enabledMonitors) {
         enabledMonitors_set.insert(mon);
     }
     for (const auto& [mon, workspaceId] : layout_copy) {
         if (enabledMonitors_set.count(mon) <= 0) {
-            auto newMonitor                               = firstAvailableMonitor(enabledMonitors);
+            auto newMonitor                         = firstAvailableMonitor(enabledMonitors);
             layouts[m_activeLayout_idx][newMonitor] = workspaceId;
             layouts[m_activeLayout_idx].erase(newMonitor);
         }


### PR DESCRIPTION
Hi,

The current implementation of the `printstate` dispatcher only includes the active vdesks. However, when I specify named vdesks in the config which are currently inactive they aren't included in the state.

I've now added them to the state. Additionally, I also fixed the json formatting for the `activedesk` and the `prinstate` dispatchers.