### PR TITLE
Switch vdesk when external focus jumps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,3 +49,8 @@ jobs:
           PKG_CONFIG_PATH: "/usr/local/share/pkgconfig/"
         run: |
           make all
+
+      - name: Run unit tests
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,8 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET
 target_link_libraries(hyprland-virtual-desktops PRIVATE rt PkgConfig::deps)
 
 install(TARGETS hyprland-virtual-desktops)
+
+enable_testing()
+add_executable(focus_memory_test tests/focus_memory_test.cpp)
+target_include_directories(focus_memory_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_test(NAME focus_memory_test COMMAND focus_memory_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,3 +46,7 @@ enable_testing()
 add_executable(focus_memory_test tests/focus_memory_test.cpp)
 target_include_directories(focus_memory_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 add_test(NAME focus_memory_test COMMAND focus_memory_test)
+
+add_executable(utils_test tests/utils_test.cpp)
+target_include_directories(utils_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_test(NAME utils_test COMMAND utils_test)

--- a/include/FocusMemory.hpp
+++ b/include/FocusMemory.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#ifndef FOCUS_MEMORY_HPP
+#define FOCUS_MEMORY_HPP
+
+#include <functional>
+#include <memory>
+
+template <typename T, template <typename> class SharedPtr = std::shared_ptr, template <typename> class WeakPtr = std::weak_ptr> class FocusMemory {
+  public:
+    using Shared = SharedPtr<T>;
+    using Weak   = WeakPtr<T>;
+
+    void remember(const Shared& item) {
+        if (item)
+            m_last = item;
+    }
+
+    Shared recall(const std::function<bool(const Shared&)>& validator) const {
+        auto locked = m_last.lock();
+        if (!locked)
+            return nullptr;
+        if (validator && !validator(locked))
+            return nullptr;
+        return locked;
+    }
+
+    void forget(const Shared& item) {
+        if (!item)
+            return;
+        auto locked = m_last.lock();
+        if (locked && locked == item)
+            m_last.reset();
+    }
+
+    void reset() { m_last.reset(); }
+
+  private:
+    Weak m_last;
+};
+
+#endif

--- a/include/VirtualDesk.hpp
+++ b/include/VirtualDesk.hpp
@@ -52,6 +52,9 @@ class VirtualDesk {
     void                            deleteInvalidMonitorOnAllLayouts(const CSharedPointer<CMonitor>&);
     static CSharedPointer<CMonitor> firstAvailableMonitor(const std::vector<CSharedPointer<CMonitor>>&);
     bool                            isWorkspaceOnActiveLayout(WORKSPACEID workspaceId);
+    void                            rememberFocusedMonitor(const CSharedPointer<CMonitor>& monitor);
+    CSharedPointer<CMonitor>        lastFocusedMonitor();
+    void                            forgetMonitor(const CSharedPointer<CMonitor>& monitor);
 
   private:
     int                m_activeLayout_idx;
@@ -59,5 +62,6 @@ class VirtualDesk {
     Layout             generateCurrentMonitorLayout();
     static std::string monitorDesc(const CSharedPointer<CMonitor>&);
     void               checkAndAdaptLayout(Layout*, const CSharedPointer<CMonitor>& exclude = nullptr);
+    CWeakPointer<CMonitor> m_lastFocusedMonitor;
 };
 #endif

--- a/include/VirtualDesk.hpp
+++ b/include/VirtualDesk.hpp
@@ -7,9 +7,10 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <hyprland/src/helpers/Monitor.hpp>
 #include "globals.hpp"
 #include "utils.hpp"
+#include "FocusMemory.hpp"
+#include <hyprland/src/helpers/Monitor.hpp>
 #include <hyprland/src/Compositor.hpp>
 
 using namespace Hyprutils::Memory;
@@ -62,6 +63,6 @@ class VirtualDesk {
     Layout             generateCurrentMonitorLayout();
     static std::string monitorDesc(const CSharedPointer<CMonitor>&);
     void               checkAndAdaptLayout(Layout*, const CSharedPointer<CMonitor>& exclude = nullptr);
-    CWeakPointer<CMonitor> m_lastFocusedMonitor;
+    FocusMemory<CMonitor, Hyprutils::Memory::CSharedPointer, Hyprutils::Memory::CWeakPointer> m_focusMemory;
 };
 #endif

--- a/include/layout_utils.hpp
+++ b/include/layout_utils.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstddef>
+
+inline int deskIdFromWorkspaceRaw(long workspaceId, std::size_t monitorCount) {
+    if (workspaceId <= 0 || monitorCount == 0)
+        return 1;
+    return static_cast<int>((workspaceId - 1) / static_cast<long>(monitorCount)) + 1;
+}
+

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -2,8 +2,9 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#include <hyprland/src/debug/Log.hpp>
 #include "globals.hpp"
+#include "layout_utils.hpp"
+#include <hyprland/src/debug/Log.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <string>
 #include <hyprland/src/Compositor.hpp>
@@ -60,6 +61,9 @@ void                                  printLog(std::string s, eLogLevel level = 
 std::string                           parseMoveDispatch(std::string& arg);
 bool                                  extractBool(std::string& arg);
 std::vector<CSharedPointer<CMonitor>> currentlyEnabledMonitors(const CSharedPointer<CMonitor>& exclude = nullptr);
+inline int                            deskIdFromWorkspace(WORKSPACEID workspaceId, size_t monitorCount) {
+    return deskIdFromWorkspaceRaw(static_cast<long>(workspaceId), monitorCount);
+}
 
 std::string                           ltrim(const std::string& s);
 std::string                           rtrim(const std::string& s);

--- a/tests/focus_memory_test.cpp
+++ b/tests/focus_memory_test.cpp
@@ -1,0 +1,56 @@
+#include "FocusMemory.hpp"
+#include <memory>
+
+int main() {
+    FocusMemory<int> tracker;
+
+    auto validatorAlways = [](const std::shared_ptr<int>&) { return true; };
+
+    if (tracker.recall(validatorAlways))
+        return 1; // unexpected initial value
+
+    auto value = std::make_shared<int>(42);
+    tracker.remember(value);
+
+    auto recalled = tracker.recall(validatorAlways);
+    if (!recalled || *recalled != 42)
+        return 2;
+
+    tracker.forget(value);
+    if (tracker.recall(validatorAlways))
+        return 3;
+
+    auto otherValue = std::make_shared<int>(7);
+    tracker.remember(otherValue);
+    auto rejected = tracker.recall([](const std::shared_ptr<int>& v) { return v && *v == 42; });
+    if (rejected)
+        return 4;
+
+    auto check = tracker.recall(validatorAlways);
+    if (!check || *check != 7)
+        return 5;
+
+    check.reset();
+    otherValue.reset();
+    if (tracker.recall(validatorAlways))
+        return 6;
+
+    FocusMemory<int> validatorTest;
+    auto initial = std::make_shared<int>(3);
+    validatorTest.remember(initial);
+    auto onlyEven = [](const std::shared_ptr<int>& v) { return v && (*v % 2 == 0); };
+    if (validatorTest.recall(onlyEven))
+        return 7;
+
+    auto even = std::make_shared<int>(4);
+    validatorTest.remember(even);
+    auto evenResult = validatorTest.recall(onlyEven);
+    if (!evenResult || *evenResult != 4)
+        return 8;
+
+    validatorTest.forget(even);
+    if (validatorTest.recall(validatorAlways))
+        return 9;
+
+    return 0;
+}

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -1,0 +1,41 @@
+#include "layout_utils.hpp"
+
+int main() {
+    if (deskIdFromWorkspaceRaw(-1, 2) != 1)
+        return 1;
+
+    if (deskIdFromWorkspaceRaw(0, 2) != 1)
+        return 2;
+
+    if (deskIdFromWorkspaceRaw(1, 2) != 1)
+        return 3;
+
+    if (deskIdFromWorkspaceRaw(2, 2) != 1)
+        return 4;
+
+    if (deskIdFromWorkspaceRaw(3, 2) != 2)
+        return 5;
+
+    if (deskIdFromWorkspaceRaw(4, 2) != 2)
+        return 6;
+
+    if (deskIdFromWorkspaceRaw(5, 2) != 3)
+        return 7;
+
+    if (deskIdFromWorkspaceRaw(6, 3) != 2)
+        return 8;
+
+    if (deskIdFromWorkspaceRaw(7, 3) != 3)
+        return 9;
+
+    if (deskIdFromWorkspaceRaw(8, 3) != 3)
+        return 10;
+
+    if (deskIdFromWorkspaceRaw(42, 5) != 9)
+        return 11;
+
+    if (deskIdFromWorkspaceRaw(10, 0) != 1)
+        return 12;
+
+    return 0;
+}


### PR DESCRIPTION
Merge after #97

## Summary
- detect workspace changes that point to another virtual desk and immediately switch to it
- share a lightweight helper for computing desk ids and cover it with a dedicated unit test
- extend the existing ctest suite to keep the helper and focus bookkeeping under CI

## Testing
- make
- cd build && ctest --output-on-failure
