### PR TITLE
Switch to desktop focus state to get active monitors/windows

### DIFF
--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -3,6 +3,7 @@
 #include <format>
 #include <ranges>
 #include <hyprland/src/managers/EventManager.hpp>
+#include <hyprland/src/desktop/state/FocusState.hpp>
 
 VirtualDeskManager::VirtualDeskManager() {
     this->conf = RememberLayoutConf::size;
@@ -120,7 +121,7 @@ int VirtualDeskManager::moveToDesk(std::string& arg, int vdeskId) {
     // monitor of the target window
     // if no arg is provided, it's the currently focussed monitor and otherwise
     // it's the monitor of the window matched by the arg regex
-    PHLMONITORREF monitor = g_pCompositor->m_lastMonitor;
+    PHLMONITORREF monitor = Desktop::focusState()->monitor();
     if (arg != "") {
         PHLWINDOW window = g_pCompositor->getWindowByRegex(arg);
         if (!window) {
@@ -188,7 +189,7 @@ void VirtualDeskManager::cycleWorkspaces() {
         return;
 
     auto                     n_monitors     = g_pCompositor->m_monitors.size();
-    CSharedPointer<CMonitor> currentMonitor = g_pCompositor->m_lastMonitor.lock();
+    CSharedPointer<CMonitor> currentMonitor = Desktop::focusState()->monitor();
 
     // TODO: implement for more than two monitors as well.
     // This probably requires to compute monitors position
@@ -291,7 +292,7 @@ void VirtualDeskManager::invalidateAllLayouts() {
 }
 
 CSharedPointer<CMonitor> VirtualDeskManager::getFocusedMonitor() {
-    CWeakPointer<CMonitor> currentMonitor = g_pCompositor->m_lastMonitor;
+    CWeakPointer<CMonitor> currentMonitor = Desktop::focusState()->monitor();
     // This can happen when we receive the "on disconnect" signal
     // let's just take first monitor we can find
     if (currentMonitor && (!currentMonitor->m_enabled || !currentMonitor->m_output)) {


### PR DESCRIPTION
Hi,

This pull request fixes the plugin to build on `hyprland-git`. 
Some things broke with https://github.com/hyprwm/Hyprland/pull/12033 which are now fixed.  