### PR TITLE
Remove Hyprland Events include

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,6 @@
 #include <hyprland/src/helpers/MiscFunctions.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
 #include <hyprland/src/debug/Log.hpp>
-#include <hyprland/src/events/Events.hpp>
 
 #include "globals.hpp"
 #include "VirtualDeskManager.hpp"


### PR DESCRIPTION
Hi,

The plugin no longer built on hyprland-git due to the Hyprland Events header file being removed. I removed this include as it seems it wasn't needed anyways.