### PR TITLE
Add hyprwire dependency to CI

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -36,6 +36,7 @@ runs:
           hyprlang \
           hyprcursor \
           hyprutils \
+          hyprwire \
           jq \
           libc++ \
           libdisplay-info \


### PR DESCRIPTION
Seems as if hyprland has another new dependency ._.