### PR TITLE
feat: update for hyprland 0.53.0 dependencies and refactor logging system for compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         if: github.ref == 'refs/heads/main'|| github.base_ref == 'main'
         with:
           INSTALL_XORG_PKGS: true
-          branch: "v0.52.1"
+          branch: "v0.53.0"
           hyprwayland: "v0.4.5"
 
       - name: Setup base on dev

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -2,7 +2,11 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#include <hyprland/src/debug/Log.hpp>
+#if __has_include(<hyprland/src/debug/log/Logger.hpp>)
+  #include <hyprland/src/debug/log/Logger.hpp>
+#else
+  #include <hyprland/src/debug/Log.hpp>
+#endif
 #include "globals.hpp"
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <string>
@@ -55,7 +59,7 @@ enum RememberLayoutConf {
 
 RememberLayoutConf                    layoutConfFromInt(const int64_t);
 RememberLayoutConf                    layoutConfFromString(const std::string& conf);
-void                                  printLog(std::string s, eLogLevel level = INFO);
+void printLog(std::string s, Hyprutils::CLI::eLogLevel level = Log::INFO);
 
 std::string                           parseMoveDispatch(std::string& arg);
 bool                                  extractBool(std::string& arg);

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -120,11 +120,11 @@ int VirtualDeskManager::moveToDesk(std::string& arg, int vdeskId) {
     // monitor of the target window
     // if no arg is provided, it's the currently focussed monitor and otherwise
     // it's the monitor of the window matched by the arg regex
-    PHLMONITORREF monitor = g_pCompositor->m_lastMonitor;
+    PHLMONITORREF monitor = g_pCompositor->getMonitorFromCursor();
     if (arg != "") {
         PHLWINDOW window = g_pCompositor->getWindowByRegex(arg);
         if (!window) {
-            printLog(std::format("Window {} does not exist???", arg), eLogLevel::ERR);
+            printLog(std::format("Window {} does not exist???", arg), Hyprutils::CLI::eLogLevel::LOG_ERR);
         } else {
             monitor = window->m_monitor;
         }
@@ -188,7 +188,7 @@ void VirtualDeskManager::cycleWorkspaces() {
         return;
 
     auto                     n_monitors     = g_pCompositor->m_monitors.size();
-    CSharedPointer<CMonitor> currentMonitor = g_pCompositor->m_lastMonitor.lock();
+    auto currentMonitor = g_pCompositor->getMonitorFromCursor();
 
     // TODO: implement for more than two monitors as well.
     // This probably requires to compute monitors position
@@ -240,12 +240,12 @@ void VirtualDeskManager::resetVdesk(const std::string& arg) {
     } catch (std::exception const& ex) { vdeskId = getDeskIdFromName(arg, false); }
 
     if (vdeskId == -1) {
-        printLog("Reset vdesk: " + arg + " not found", eLogLevel::WARN);
+        printLog("Reset vdesk: " + arg + " not found", Hyprutils::CLI::eLogLevel::LOG_WARN);
         return;
     }
 
     if (!vdesksMap.contains(vdeskId)) {
-        printLog("Reset vdesk: " + arg + " not found in map. This should not happen :O", eLogLevel::ERR);
+        printLog("Reset vdesk: " + arg + " not found in map. This should not happen :O", Hyprutils::CLI::eLogLevel::LOG_ERR);
         return;
     }
 
@@ -291,7 +291,7 @@ void VirtualDeskManager::invalidateAllLayouts() {
 }
 
 CSharedPointer<CMonitor> VirtualDeskManager::getFocusedMonitor() {
-    CWeakPointer<CMonitor> currentMonitor = g_pCompositor->m_lastMonitor;
+    PHLMONITORREF currentMonitor = g_pCompositor->getMonitorFromCursor();
     // This can happen when we receive the "on disconnect" signal
     // let's just take first monitor we can find
     if (currentMonitor && (!currentMonitor->m_enabled || !currentMonitor->m_output)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,8 +3,16 @@
 #include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/helpers/MiscFunctions.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
-#include <hyprland/src/debug/Log.hpp>
-#include <hyprland/src/events/Events.hpp>
+#if __has_include(<hyprland/src/debug/log/Logger.hpp>)
+  #include <hyprland/src/debug/log/Logger.hpp>
+#else
+  #include <hyprland/src/debug/Log.hpp>
+#endif
+#if __has_include(<hyprland/src/events/Events.hpp>)
+  #include <hyprland/src/events/Events.hpp>
+#else
+  #include <hyprland/src/managers/EventManager.hpp>
+#endif
 
 #include "globals.hpp"
 #include "VirtualDeskManager.hpp"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,10 +1,10 @@
 #include "utils.hpp"
 
-void printLog(std::string s, eLogLevel level) {
+void printLog(std::string s, Hyprutils::CLI::eLogLevel level) {
     // #ifdef DEBUG
     //     std::cout << "[virtual-desktops] " + s << std::endl;
     // #endif
-    Debug::log(level, "[virtual-desktops] {}", s);
+  Log::logger->log(level, "[virtual-desktops] {}", s);
 }
 
 std::string parseMoveDispatch(std::string& arg) {


### PR DESCRIPTION
This commit updates the hyprland branch version from v0.52.1 to v0.53.0 and refactors the logging system to use the new hyprland logger API. The changes include updating header includes to support both old and new hyprland versions using `__has_include`, replacing the old `eLogLevel` enum with `Hyprutils::CLI::eLogLevel`, and updating log calls to use the new logger interface. Additionally, the code now uses `getMonitorFromCursor()` instead of `m_lastMonitor` for better monitor detection.