### PR TITLE
Use typed event bus

### DIFF
--- a/include/VirtualDesk.hpp
+++ b/include/VirtualDesk.hpp
@@ -15,7 +15,7 @@ using namespace Hyprutils::Memory;
 
 typedef std::unordered_map<int, int> WorkspaceMap;
 // map with CMonitor* -> hyprland workspace id
-typedef std::unordered_map<const CSharedPointer<CMonitor>, WORKSPACEID> Layout;
+typedef std::unordered_map<const CSharedPointer<CMonitor>, WORKSPACEID> MonitorLayout;
 typedef std::string                                                     MonitorName;
 
 // implement `std::hash` for the CSharedPointer<Monitor> to work with `std::unordered_map`
@@ -38,10 +38,10 @@ class VirtualDesk {
     VirtualDesk(int id = 1, std::string name = "1");
     int                             id;
     std::string                     name;
-    std::vector<Layout>             layouts;
+    std::vector<MonitorLayout>      layouts;
 
-    const Layout&                   activeLayout(const RememberLayoutConf&, const CSharedPointer<CMonitor>& exclude = nullptr);
-    Layout&                         searchActiveLayout(const RememberLayoutConf&, const CSharedPointer<CMonitor>& exclude = nullptr);
+    const MonitorLayout&            activeLayout(const RememberLayoutConf&, const CSharedPointer<CMonitor>& exclude = nullptr);
+    MonitorLayout&                  searchActiveLayout(const RememberLayoutConf&, const CSharedPointer<CMonitor>& exclude = nullptr);
     std::unordered_set<std::string> setFromMonitors(const std::vector<CSharedPointer<CMonitor>>&);
     void                            changeWorkspaceOnMonitor(WORKSPACEID, const CSharedPointer<CMonitor>&);
     void                            invalidateActiveLayout();
@@ -55,8 +55,8 @@ class VirtualDesk {
   private:
     int                m_activeLayout_idx;
     bool               activeIsValid = false;
-    Layout             generateCurrentMonitorLayout();
+    MonitorLayout      generateCurrentMonitorLayout();
     static std::string monitorDesc(const CSharedPointer<CMonitor>&);
-    void               checkAndAdaptLayout(Layout*, const CSharedPointer<CMonitor>& exclude = nullptr);
+    void               checkAndAdaptLayout(MonitorLayout*, const CSharedPointer<CMonitor>& exclude = nullptr);
 };
 #endif

--- a/src/VirtualDesk.cpp
+++ b/src/VirtualDesk.cpp
@@ -11,7 +11,7 @@ VirtualDesk::VirtualDesk(int id, std::string name) {
     m_activeLayout_idx = 0;
 }
 
-const Layout& VirtualDesk::activeLayout(const RememberLayoutConf& conf, const CSharedPointer<CMonitor>& exclude) {
+const MonitorLayout& VirtualDesk::activeLayout(const RememberLayoutConf& conf, const CSharedPointer<CMonitor>& exclude) {
     if (!activeIsValid) {
         activeIsValid = true;
         searchActiveLayout(conf, exclude);
@@ -19,7 +19,7 @@ const Layout& VirtualDesk::activeLayout(const RememberLayoutConf& conf, const CS
     return layouts[m_activeLayout_idx];
 }
 
-Layout& VirtualDesk::searchActiveLayout(const RememberLayoutConf& conf, const CSharedPointer<CMonitor>& exclude) {
+MonitorLayout& VirtualDesk::searchActiveLayout(const RememberLayoutConf& conf, const CSharedPointer<CMonitor>& exclude) {
 
     auto monitors = currentlyEnabledMonitors(exclude);
     switch (conf) {
@@ -88,7 +88,7 @@ void VirtualDesk::deleteInvalidMonitorOnAllLayouts(const CSharedPointer<CMonitor
 }
 
 CSharedPointer<CMonitor> VirtualDesk::deleteInvalidMonitor(const CSharedPointer<CMonitor>& monitor) {
-    Layout layout_copy(layouts[m_activeLayout_idx]);
+    MonitorLayout layout_copy(layouts[m_activeLayout_idx]);
     for (auto const& [mon, workspaceId] : layout_copy) {
         if (mon == monitor) {
             auto newMonitor = firstAvailableMonitor(currentlyEnabledMonitors(monitor));
@@ -102,7 +102,7 @@ CSharedPointer<CMonitor> VirtualDesk::deleteInvalidMonitor(const CSharedPointer<
 }
 
 void VirtualDesk::deleteInvalidMonitorsOnActiveLayout() {
-    Layout                                       layout_copy(layouts[m_activeLayout_idx]);
+    MonitorLayout                                layout_copy(layouts[m_activeLayout_idx]);
     auto                                         enabledMonitors = currentlyEnabledMonitors();
     std::unordered_set<CSharedPointer<CMonitor>> enabledMonitors_set;
     for (const auto& mon : enabledMonitors) {
@@ -141,11 +141,11 @@ bool VirtualDesk::isWorkspaceOnActiveLayout(WORKSPACEID workspaceId) {
     return false;
 }
 
-void VirtualDesk::checkAndAdaptLayout(Layout* layout, const CSharedPointer<CMonitor>& exclude) {
+void VirtualDesk::checkAndAdaptLayout(MonitorLayout* layout, const CSharedPointer<CMonitor>& exclude) {
     auto enabledMons = currentlyEnabledMonitors(exclude);
     if (enabledMons.empty())
         return;
-    for (const auto& [mon, wid] : Layout(*layout)) {
+    for (const auto& [mon, wid] : MonitorLayout(*layout)) {
         if (!mon || !mon->m_enabled || mon == exclude) {
             // Let's try to find a "new" monitor which wasn't in
             // the layout before. If we don't find it, not much we can
@@ -169,10 +169,10 @@ std::unordered_set<std::string> VirtualDesk::setFromMonitors(const std::vector<C
     return set;
 }
 
-Layout VirtualDesk::generateCurrentMonitorLayout() {
-    Layout layout;
+MonitorLayout VirtualDesk::generateCurrentMonitorLayout() {
+    MonitorLayout layout;
 
-    auto   monitors = currentlyEnabledMonitors();
+    auto          monitors = currentlyEnabledMonitors();
     if (PHANDLE && isVerbose())
         printLog("vdesk " + name + " computing new layout for " + std::to_string(monitors.size()) + " monitors");
     auto vdeskFirstWorkspace = (this->id - 1) * monitors.size() + 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,31 +3,32 @@
 #include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/helpers/MiscFunctions.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
+#include <hyprland/src/event/EventBus.hpp>
 
 #include "globals.hpp"
 #include "VirtualDeskManager.hpp"
 #include "utils.hpp"
 #include "sticky_apps.hpp"
 
-#include <any>
+#include <src/desktop/DesktopTypes.hpp>
 #include <vector>
 
 using namespace Hyprutils::Memory;
 
-static CSharedPointer<HOOK_CALLBACK_FN> onWorkspaceChangeHook   = nullptr;
-static CSharedPointer<HOOK_CALLBACK_FN> onWindowOpenHook        = nullptr;
-static CSharedPointer<HOOK_CALLBACK_FN> onConfigReloadedHook    = nullptr;
-static CSharedPointer<HOOK_CALLBACK_FN> onPreMonitorAddedHook   = nullptr;
-static CSharedPointer<HOOK_CALLBACK_FN> onMonitorAddedHook      = nullptr;
-static CSharedPointer<HOOK_CALLBACK_FN> onPreMonitorRemovedHook = nullptr;
-static CSharedPointer<HOOK_CALLBACK_FN> onMonitorRemovedHook    = nullptr;
+static CHyprSignalListener           onWorkspaceChangeHook   = nullptr;
+static CHyprSignalListener           onWindowOpenHook        = nullptr;
+static CHyprSignalListener           onConfigReloadedHook    = nullptr;
+static CHyprSignalListener           onPreMonitorAddedHook   = nullptr;
+static CHyprSignalListener           onMonitorAddedHook      = nullptr;
+static CHyprSignalListener           onPreMonitorRemovedHook = nullptr;
+static CHyprSignalListener           onMonitorRemovedHook    = nullptr;
 
-std::unique_ptr<VirtualDeskManager>     manager = std::make_unique<VirtualDeskManager>();
-std::vector<StickyApps::SStickyRule>    stickyRules;
-bool                                    notifiedInit          = false;
-bool                                    monitorLayoutChanging = false;
+std::unique_ptr<VirtualDeskManager>  manager = std::make_unique<VirtualDeskManager>();
+std::vector<StickyApps::SStickyRule> stickyRules;
+bool                                 notifiedInit          = false;
+bool                                 monitorLayoutChanging = false;
 
-void                                    parseNamesConf(std::string& conf) {
+void                                 parseNamesConf(std::string& conf) {
     size_t      pos;
     size_t      delim;
     std::string rule;
@@ -318,32 +319,29 @@ SDispatchResult resetVDeskDispatch(std::string arg) {
     return SDispatchResult{};
 }
 
-void onWorkspaceChange(void*, SCallbackInfo&, std::any val) {
+void onWorkspaceChange(PHLWORKSPACE workspace) {
     if (monitorLayoutChanging)
         return;
-    auto        workspace   = std::any_cast<PHLWORKSPACE>(val);
-    WORKSPACEID workspaceID = std::any_cast<PHLWORKSPACE>(val)->m_id;
 
-    auto        monitor = workspace->m_monitor.lock();
+    auto monitor = workspace->m_monitor.lock();
     if (!monitor || !monitor->m_enabled)
         return;
 
-    manager->activeVdesk()->changeWorkspaceOnMonitor(workspaceID, monitor);
+    manager->activeVdesk()->changeWorkspaceOnMonitor(workspace->m_id, monitor);
     if (isVerbose()) {
         auto vdesk = manager->activeVdesk();
-        printLog("workspace changed on vdesk " + std::to_string(vdesk->id) + ": workspace id " + std::to_string(workspaceID) + "; on monitor " + std::to_string(monitor->m_id));
+        printLog("workspace changed on vdesk " + std::to_string(vdesk->id) + ": workspace id " + std::to_string(workspace->m_id) + "; on monitor " + std::to_string(monitor->m_id));
     }
 }
 
-void onWindowOpen(void*, SCallbackInfo&, std::any val) {
-    auto window = std::any_cast<PHLWINDOW>(val);
-    int  vdesk  = StickyApps::matchRuleOnWindow(stickyRules, manager, window);
+void onWindowOpen(PHLWINDOW window) {
+    // auto window = std::any_cast<PHLWINDOW>(val);
+    int vdesk = StickyApps::matchRuleOnWindow(stickyRules, manager, window);
     if (vdesk > 0)
         manager->changeActiveDesk(vdesk, true);
 }
 
-void onPreMonitorRemoved(void*, SCallbackInfo&, std::any val) {
-    CSharedPointer<CMonitor> monitor = std::any_cast<CSharedPointer<CMonitor>>(val);
+void onPreMonitorRemoved(PHLMONITOR monitor) {
     if (monitor->m_name == std::string("HEADLESS-1")) {
         return;
     }
@@ -352,8 +350,7 @@ void onPreMonitorRemoved(void*, SCallbackInfo&, std::any val) {
     monitorLayoutChanging = true;
 }
 
-void onMonitorRemoved(void*, SCallbackInfo&, std::any val) {
-    CSharedPointer<CMonitor> monitor = std::any_cast<CSharedPointer<CMonitor>>(val);
+void onMonitorRemoved(PHLMONITOR monitor) {
     if (monitor->m_name == std::string("HEADLESS-1")) {
         return;
     }
@@ -368,8 +365,7 @@ void onMonitorRemoved(void*, SCallbackInfo&, std::any val) {
     }
 }
 
-void onPreMonitorAdded(void*, SCallbackInfo&, std::any val) {
-    CSharedPointer<CMonitor> monitor = std::any_cast<CSharedPointer<CMonitor>>(val);
+void onPreMonitorAdded(PHLMONITOR monitor) {
     if (monitor->m_name == std::string("HEADLESS-1")) {
         return;
     }
@@ -378,8 +374,7 @@ void onPreMonitorAdded(void*, SCallbackInfo&, std::any val) {
     monitorLayoutChanging = true;
 }
 
-void onMonitorAdded(void*, SCallbackInfo&, std::any val) {
-    CSharedPointer<CMonitor> monitor = std::any_cast<CSharedPointer<CMonitor>>(val);
+void onMonitorAdded(PHLMONITOR monitor) {
     if (monitor->m_name == std::string("HEADLESS-1")) {
         return;
     }
@@ -392,7 +387,7 @@ void onMonitorAdded(void*, SCallbackInfo&, std::any val) {
     StickyApps::matchRules(stickyRules, manager);
 }
 
-void onConfigReloaded(void*, SCallbackInfo&, std::any val) {
+void onConfigReloaded() {
     static auto* const PNOTIFYINIT = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, NOTIFY_INIT)->getDataStaticPtr();
     if (**PNOTIFYINIT && !notifiedInit) {
         HyprlandAPI::addNotification(PHANDLE, "Virtual desk Initialized successfully!", CHyprColor{0.f, 1.f, 1.f, 1.f}, 5000);
@@ -479,13 +474,13 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     // Keywords
     HyprlandAPI::addConfigKeyword(PHANDLE, STICKY_RULES_KEYW, parseStickyRule, Hyprlang::SHandlerOptions{});
 
-    onWorkspaceChangeHook   = HyprlandAPI::registerCallbackDynamic(PHANDLE, "workspace", onWorkspaceChange);
-    onWindowOpenHook        = HyprlandAPI::registerCallbackDynamic(PHANDLE, "openWindow", onWindowOpen);
-    onConfigReloadedHook    = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", onConfigReloaded);
-    onPreMonitorAddedHook   = HyprlandAPI::registerCallbackDynamic(PHANDLE, "preMonitorAdded", onPreMonitorAdded);
-    onPreMonitorRemovedHook = HyprlandAPI::registerCallbackDynamic(PHANDLE, "preMonitorRemoved", onPreMonitorRemoved);
-    onMonitorAddedHook      = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorAdded", onMonitorAdded);
-    onMonitorRemovedHook    = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorRemoved", onMonitorRemoved);
+    onWorkspaceChangeHook   = Event::bus()->m_events.workspace.active.listen(onWorkspaceChange);
+    onWindowOpenHook        = Event::bus()->m_events.window.open.listen(onWindowOpen);
+    onConfigReloadedHook    = Event::bus()->m_events.config.reloaded.listen(onConfigReloaded);
+    onPreMonitorAddedHook   = Event::bus()->m_events.monitor.preAdded.listen(onPreMonitorAdded);
+    onPreMonitorRemovedHook = Event::bus()->m_events.monitor.preRemoved.listen(onPreMonitorRemoved);
+    onMonitorAddedHook      = Event::bus()->m_events.monitor.added.listen(onMonitorAdded);
+    onMonitorRemovedHook    = Event::bus()->m_events.monitor.removed.listen(onMonitorRemoved);
 
     registerHyprctlCommands();
 


### PR DESCRIPTION
Hi,

Hyprland no longer supports the `registerCallbackDynamic` function and instead provides an typed event bus for listening to events. I've updated the event listeners to be compatible with the new API.

Also, there is a new `Layout` namespace in Hyprland which conflicted with the `Layout` typedef and thus I renamed it to `MonitorLayout`