### PR TITLE
feat: migrate to Hyprland's V2 config API

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -53,6 +53,7 @@ runs:
           libxkbfile \
           libxcursor \
           lld \
+          lua \
           meson \
           muparser \
           ninja \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,8 @@ jobs:
         if: github.ref == 'refs/heads/main'|| github.base_ref == 'main'
         with:
           INSTALL_XORG_PKGS: true
-          branch: "v0.54.0"
-          hyprwayland: "v0.4.5"
+          branch: "v0.55.2"
+          hyprwayland: "v0.4.6"
 
       - name: Setup base on dev
         uses: ./.github/actions/setup_base

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_EXPORT_COMPILE_COMMANDS)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_compile_definitions(DEBUG)
+    add_compile_definitions(HYPRLAND_VIRTUAL_DESKTOPS_DEBUG)
 else()
     add_compile_options(-O2)
 endif()

--- a/README.md
+++ b/README.md
@@ -186,6 +186,22 @@ This plugin exposes a few configuration options, under the `plugin:virtual-deskt
 
 #### Example config
 
+* Lua Config
+
+```lua
+hl.config({
+    plugin = {
+        virtual_desktops = {
+            names = "1:coding, 2:internet, 3:mail and chats",
+            cycleworkspaces = 0,
+            notifyinit = 1,
+            verbose_logging = 1,
+        },
+    }
+})
+```
+
+* Or hyprland/legacy Config
 ```ini
 stickyrule = class:^(kittysticky)$,3
 stickyrule = title:thunderbird,mail
@@ -200,6 +216,8 @@ plugin {
     }
 }
 ```
+
+
 
 ## Layouts
 

--- a/include/globals.hpp
+++ b/include/globals.hpp
@@ -1,5 +1,23 @@
 #pragma once
 
 #include <hyprland/src/plugins/PluginAPI.hpp>
+#include <hyprland/src/config/values/types/IntValue.hpp>
+#include <hyprland/src/config/values/types/StringValue.hpp>
 
 inline HANDLE PHANDLE = nullptr;
+
+struct SConfig {
+    SP<Config::Values::CStringValue> names;
+    SP<Config::Values::CIntValue>    cycleWorkspaces;
+    SP<Config::Values::CStringValue> rememberLayout;
+    SP<Config::Values::CIntValue>    notifyInit;
+    SP<Config::Values::CIntValue>    verboseLogging;
+};
+
+inline SConfig config = {
+    .names           = makeShared<Config::Values::CStringValue>("plugin:virtual-desktops:names", "map a vdesk id with a name", "unset"),
+    .cycleWorkspaces = makeShared<Config::Values::CIntValue>("plugin:virtual-desktops:cycleworkspaces", "if set to 1, cycles between vdesks", 1),
+    .rememberLayout  = makeShared<Config::Values::CStringValue>("plugin:virtual-desktops:rememberlayout", "chooses how layouts should be remembered", "unset"),
+    .notifyInit      = makeShared<Config::Values::CIntValue>("plugin:virtual-desktops:notifyinit", "chooses whether to display the startup notification", 1),
+    .verboseLogging  = makeShared<Config::Values::CIntValue>("plugin:virtual-desktops:verbose_logging", "whether to log more stuff", 0),
+};

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "globals.hpp"
 #ifndef UTILS_H
 #define UTILS_H
 
@@ -9,12 +10,6 @@
 #include <hyprutils/cli/Logger.hpp>
 
 using namespace Hyprutils::Memory;
-
-const std::string VIRTUALDESK_NAMES_CONF = "plugin:virtual-desktops:names";
-const std::string CYCLEWORKSPACES_CONF   = "plugin:virtual-desktops:cycleworkspaces";
-const std::string REMEMBER_LAYOUT_CONF   = "plugin:virtual-desktops:rememberlayout";
-const std::string NOTIFY_INIT            = "plugin:virtual-desktops:notifyinit";
-const std::string VERBOSE_LOGS           = "plugin:virtual-desktops:verbose_logging";
 
 const std::string STICKY_RULES_KEYW = "stickyrule";
 
@@ -65,5 +60,10 @@ std::string                           ltrim(const std::string& s);
 std::string                           rtrim(const std::string& s);
 std::string                           trim(const std::string& s);
 
-bool                                  isVerbose();
+inline bool                           isVerbose() {
+    if (!PHANDLE) {
+        return true;
+    }
+    return config.verboseLogging->value();
+}
 #endif

--- a/src/VirtualDeskManager.cpp
+++ b/src/VirtualDeskManager.cpp
@@ -179,14 +179,12 @@ void VirtualDeskManager::loadLayoutConf() {
     // Maybe in a future release :)
     if (confLoaded)
         return;
-    static auto* const PREMEMBER_LAYOUT = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, REMEMBER_LAYOUT_CONF)->getDataStaticPtr();
-    conf                                = layoutConfFromString(*PREMEMBER_LAYOUT);
-    confLoaded                          = true;
+    conf       = layoutConfFromString(config.rememberLayout->value());
+    confLoaded = true;
 }
 
 void VirtualDeskManager::cycleWorkspaces() {
-    static auto* const PCYCLEWORKSPACES = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, CYCLEWORKSPACES_CONF)->getDataStaticPtr();
-    if (!**PCYCLEWORKSPACES)
+    if (!config.cycleWorkspaces->value())
         return;
 
     auto                     n_monitors     = g_pCompositor->m_monitors.size();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "utils.hpp"
 #include "sticky_apps.hpp"
 
+#include <plugins/PluginAPI.hpp>
 #include <src/desktop/DesktopTypes.hpp>
 #include <vector>
 
@@ -28,7 +29,8 @@ std::vector<StickyApps::SStickyRule> stickyRules;
 bool                                 notifiedInit          = false;
 bool                                 monitorLayoutChanging = false;
 
-void                                 parseNamesConf(std::string& conf) {
+void                                 parseNamesConf(const std::string& _conf) {
+    std::string conf = _conf;
     size_t      pos;
     size_t      delim;
     std::string rule;
@@ -143,10 +145,7 @@ SDispatchResult moveToNextDeskSilentDispatch(std::string arg) {
 }
 
 std::string printVDeskDispatch(eHyprCtlOutputFormat format, std::string arg) {
-    static auto* const PVDESKNAMESCONF = (Hyprlang::STRING const*)(HyprlandAPI::getConfigValue(PHANDLE, VIRTUALDESK_NAMES_CONF))->getDataStaticPtr();
-
-    auto               vdeskNamesConf = std::string{*PVDESKNAMESCONF};
-    parseNamesConf(vdeskNamesConf);
+    parseNamesConf(config.names->value());
 
     arg.erase(0, PRINTDESK_DISPATCH_STR.length());
     printLog(std::format("Got {}", arg));
@@ -388,14 +387,11 @@ void onMonitorAdded(PHLMONITOR monitor) {
 }
 
 void onConfigReloaded() {
-    static auto* const PNOTIFYINIT = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, NOTIFY_INIT)->getDataStaticPtr();
-    if (**PNOTIFYINIT && !notifiedInit) {
+    if (config.notifyInit->value() && !notifiedInit) {
         HyprlandAPI::addNotification(PHANDLE, "Virtual desk Initialized successfully!", CHyprColor{0.f, 1.f, 1.f, 1.f}, 5000);
         notifiedInit = true;
     }
-    static auto* const PVDESKNAMESCONF = (Hyprlang::STRING const*)(HyprlandAPI::getConfigValue(PHANDLE, VIRTUALDESK_NAMES_CONF))->getDataStaticPtr();
-    auto               vdeskNamesConf  = std::string{*PVDESKNAMESCONF};
-    parseNamesConf(vdeskNamesConf);
+    parseNamesConf(config.names->value());
     manager->loadLayoutConf();
 }
 
@@ -465,11 +461,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addDispatcherV2(PHANDLE, RESET_VDESK_DISPATCH_STR, resetVDeskDispatch);
 
     // Configs
-    HyprlandAPI::addConfigValue(PHANDLE, VIRTUALDESK_NAMES_CONF, Hyprlang::STRING{"unset"});
-    HyprlandAPI::addConfigValue(PHANDLE, CYCLEWORKSPACES_CONF, Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, REMEMBER_LAYOUT_CONF, Hyprlang::STRING{REMEMBER_SIZE.c_str()});
-    HyprlandAPI::addConfigValue(PHANDLE, NOTIFY_INIT, Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, VERBOSE_LOGS, Hyprlang::INT{0});
+    HyprlandAPI::addConfigValueV2(PHANDLE, config.names);
+    HyprlandAPI::addConfigValueV2(PHANDLE, config.cycleWorkspaces);
+    HyprlandAPI::addConfigValueV2(PHANDLE, config.rememberLayout);
+    HyprlandAPI::addConfigValueV2(PHANDLE, config.notifyInit);
+    HyprlandAPI::addConfigValueV2(PHANDLE, config.verboseLogging);
 
     // Keywords
     HyprlandAPI::addConfigKeyword(PHANDLE, STICKY_RULES_KEYW, parseStickyRule, Hyprlang::SHandlerOptions{});

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,7 +2,7 @@
 #include "globals.hpp"
 
 void printLog(std::string s, Hyprutils::CLI::eLogLevel level) {
-    // #ifdef DEBUG
+    // #ifdef HYPRLAND_VIRTUAL_DESKTOPS_DEBUG
     //     std::cout << "[virtual-desktops] " + s << std::endl;
     // #endif
     Log::logger->log(level, "[virtual-desktops] {}", s);
@@ -49,14 +49,6 @@ RememberLayoutConf layoutConfFromString(const std::string& conf) {
     else if (conf == REMEMBER_SIZE)
         return RememberLayoutConf::size;
     return RememberLayoutConf::monitors;
-}
-
-bool isVerbose() {
-    // this might happen if called before plugin is initalized
-    if (!PHANDLE)
-        return true;
-    static auto* const PVERBOSELOGS = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, VERBOSE_LOGS)->getDataStaticPtr();
-    return **PVERBOSELOGS;
 }
 
 std::vector<CSharedPointer<CMonitor>> currentlyEnabledMonitors(const CSharedPointer<CMonitor>& exclude) {


### PR DESCRIPTION

Fix https://github.com/levnikmyskin/hyprland-virtual-desktops/issues/121
* `HyprlandAPI::addConfigValue` and `HyprlandAPI::getConfigValue` is deprecated, use `HyprlandAPI::addConfigValueV2` to bind a shared variable as config.


Tested configs:
* Old/legacy/hyprlang config
```
plugin {
    virtual-desktops {
        names = 1:config, 2:coding, 3:work, 4:paper, 5:misc, 6:explorer, 7:zero, 8:media, 9:chat, 10:fish
        cycleworkspaces = 0
        notifyinit = 1
        verbose_logging = 1
    }
}

```

* New/lua config
```
hl.config({
    plugin = {
        virtual_desktops = {
            names = "1:config, 2:coding, 3:work, 4:paper, 5:misc, 6:explorer, 7:zero, 8:media, 9:chat, 10:fish",
            cycleworkspaces = 0,
            notifyinit = 1,
            verbose_logging = 1,
        },
    }
})
```

> :warning: 
> The key of plugin'name is different, becase Lua ConfigManager use a special function to process the config value name

https://github.com/hyprwm/Hyprland/blob/d8008a81686d28a653e178a095e13694289d0a82/src/config/lua/ConfigManager.cpp#L824-L829

