### PR TITLE
feat: Monitor order

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,7 @@ This plugin exposes a few configuration options, under the `plugin:virtual-deskt
 ```lua
 hl.config({
     plugin = {
-        -- Note: Bracket notation is required due to the hyphen in the plugin name
-        ["virtual-desktops"] = {
+        ["virtual_desktops"] = {
             names = "1:coding, 2:internet, 3:mail and chats",
             cycleworkspaces = 0,
             rememberlayout = "size",

--- a/README.md
+++ b/README.md
@@ -244,9 +244,11 @@ This plugin exposes a few configuration options, under the `plugin:virtual-deskt
 | rememberlayout  | chooses how layouts should be remembered (see [Layouts](#Layouts)), defaults to `size`                                                                                                                         | `none`, `size` or `monitors` | `remember = size`                                |
 | notifyinit      | chooses whether to display the startup notification, defaults to 1                                                                                                                                             | `0` or `1`                   | `notifyinit = 0`                                 |
 | verbose_logging | whether to log more stuff, defaults to 0                                                                                                                                                                       | `0` or `1`                   | `verbose_logging = 0`                            |
+| monitor_order   | comma-separated list of monitors in desired order (left to right)                                                                                                                                              | `string`, see below          | `monitor_order = DP-2, DP-1, DP-3`               |
 
 - The `names` config option maps virtual desktop IDs to a name (you can then use this with the hyprctl [dispatchers](#hyprctl-dispatchers));
 - `cycleworkspaces`: THIS CURRENTLY DOES NOT WORK WITH MORE THAN 2 MONITORS. If you need this feature, please feel welcome to submit a PR ^^.
+- `monitor_order`: specifies the order of monitors (e.g. left to right) to layout virtual desktops workspaces on them consistently. If unset, defaults to Hyprland's internal discovery order.
 
 #### Example config
 
@@ -262,6 +264,7 @@ hl.config({
             rememberlayout = "size",
             notifyinit = 1,
             verbose_logging = 1,
+            monitor_order = "DP-2, DP-1, DP-3",
         },
     }
 })
@@ -279,6 +282,7 @@ plugin {
         rememberlayout = size
         notifyinit = 0
         verbose_logging = 0
+        monitor_order = DP-2, DP-1, DP-3
     }
 }
 ```

--- a/include/globals.hpp
+++ b/include/globals.hpp
@@ -12,6 +12,7 @@ struct SConfig {
     SP<Config::Values::CStringValue> rememberLayout;
     SP<Config::Values::CIntValue>    notifyInit;
     SP<Config::Values::CIntValue>    verboseLogging;
+    SP<Config::Values::CStringValue> monitorOrder;
 };
 
 inline SConfig config = {
@@ -20,4 +21,5 @@ inline SConfig config = {
     .rememberLayout  = makeShared<Config::Values::CStringValue>("plugin:virtual-desktops:rememberlayout", "chooses how layouts should be remembered", "unset"),
     .notifyInit      = makeShared<Config::Values::CIntValue>("plugin:virtual-desktops:notifyinit", "chooses whether to display the startup notification", 1),
     .verboseLogging  = makeShared<Config::Values::CIntValue>("plugin:virtual-desktops:verbose_logging", "whether to log more stuff", 0),
+    .monitorOrder    = makeShared<Config::Values::CStringValue>("plugin:virtual-desktops:monitor_order", "comma-separated list of monitors in order", "unset"),
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -468,6 +468,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValueV2(PHANDLE, config.rememberLayout);
     HyprlandAPI::addConfigValueV2(PHANDLE, config.notifyInit);
     HyprlandAPI::addConfigValueV2(PHANDLE, config.verboseLogging);
+    HyprlandAPI::addConfigValueV2(PHANDLE, config.monitorOrder);
 
     // Keywords
     HyprlandAPI::addConfigKeyword(PHANDLE, STICKY_RULES_KEYW, parseStickyRule, Hyprlang::SHandlerOptions{});

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,8 @@
 #include "utils.hpp"
 #include "globals.hpp"
 #include <src/state/MonitorState.hpp>
+#include <algorithm>
+#include <ranges>
 
 void printLog(std::string s, Hyprutils::CLI::eLogLevel level) {
     // #ifdef HYPRLAND_VIRTUAL_DESKTOPS_DEBUG
@@ -73,6 +75,27 @@ std::vector<CSharedPointer<Monitor::CMonitor>> currentlyEnabledMonitors(const CS
 
         return mon->m_enabled;
     });
+
+    std::string order_str = config.monitorOrder->value();
+    if (order_str != "unset" && !order_str.empty()) {
+        std::vector<std::string> order;
+        for (const auto subrange : std::views::split(order_str, ',')) {
+            order.push_back(trim(std::string{subrange.begin(), subrange.end()}));
+        }
+
+        std::sort(monitors.begin(), monitors.end(), [&order](const auto& a, const auto& b) {
+            auto it_a = std::find(order.begin(), order.end(), a->m_name);
+            auto it_b = std::find(order.begin(), order.end(), b->m_name);
+
+            if (it_a != order.end() && it_b != order.end()) {
+                return it_a < it_b;
+            }
+            if (it_a != order.end()) return true;
+            if (it_b != order.end()) return false;
+            return a->m_name < b->m_name;
+        });
+    }
+
     return monitors;
 }
 


### PR DESCRIPTION
Just adding the ability for users to order their monitor workspaces in a vdesk using a static ordering in case monitor ID order does not follow physical layout